### PR TITLE
[RAPTOR-8184] A merge base commit should be examined against a remote branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ test-full: test-unit test-functional
 .PHONY: test-full
 
 test-unit:
-	set -ex; PYTHONPATH=src pytest tests/unit
+	set -ex; PYTHONPATH=.:src pytest tests/unit
 .PHONY: test-unit
 
 test-functional: validate-env-DATAROBOT_WEBSERVER validate-env-DATAROBOT_API_TOKEN
-	set -ex; PYTHONPATH=src pytest tests/functional
+	set -ex; PYTHONPATH=.:src pytest tests/functional
 .PHONY: test
 
 black:

--- a/deps/dev-requirements.txt
+++ b/deps/dev-requirements.txt
@@ -1,2 +1,2 @@
-black
-pycodestyle
+black==22.3.0
+pycodestyle==2.8.0

--- a/src/common/git_tool.py
+++ b/src/common/git_tool.py
@@ -30,6 +30,12 @@ class GitTool:
         except TypeError:
             return 0
 
+    def num_remotes(self):
+        return len(self.repo.remotes)
+
+    def remote_name(self):
+        return self.repo.remote().name if self.num_remotes() else None
+
     def find_changed_files(self, to_commit_sha, from_commit_sha=None):
         to_commit = self.repo.commit(to_commit_sha)
         if from_commit_sha:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,6 +26,14 @@ def _write_to_file(file_path, content):
         f.write(content)
 
 
+def make_a_change_and_commit(git_repo, file_paths, index):
+    for file_path in file_paths:
+        with open(file_path, "a") as f:
+            f.write(f"\n# Automatic change ({index})")
+    git_repo.index.add([str(f) for f in file_paths])
+    git_repo.index.commit(f"Change number {index}")
+
+
 @pytest.fixture
 def common_path(repo_root_path):
     return repo_root_path / "common"

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -2,6 +2,8 @@ import pytest
 
 from common.convertors import MemoryConvertor
 from common.exceptions import InvalidMemoryValue
+from common.git_tool import GitTool
+from tests.unit.conftest import make_a_change_and_commit
 
 
 class TestConvertor:
@@ -16,3 +18,61 @@ class TestConvertor:
         with pytest.raises(InvalidMemoryValue) as ex:
             MemoryConvertor.to_bytes(invalid_configured_memory)
         assert "The memory value format is invalid" in str(ex)
+
+
+class TestGitTool:
+    def test_changed_files_between_commits(
+        self, options, git_repo, repo_root_path, init_repo_with_models_factory, common_filepath
+    ):
+        init_repo_with_models_factory(2, is_multi=False)
+
+        make_a_change_and_commit(git_repo, [str(common_filepath)], 1)
+
+        first_model_main_program_filepath = repo_root_path / "model_0" / "custom.py"
+        assert first_model_main_program_filepath.is_file()
+        make_a_change_and_commit(
+            git_repo, [str(common_filepath), first_model_main_program_filepath], 2
+        )
+
+        repo_tool = GitTool(repo_root_path)
+        changed_files1, deleted_files = repo_tool.find_changed_files("HEAD")
+        assert len(changed_files1) == 2, changed_files1
+        assert not deleted_files
+        changed_files2, _ = repo_tool.find_changed_files("HEAD", "HEAD~1")
+        assert len(changed_files2) == 2, changed_files2
+        assert set(changed_files2) == set(changed_files1)
+
+        changed_files3, _ = repo_tool.find_changed_files("HEAD~1", "HEAD~2")
+        assert len(changed_files3) == 1, changed_files2
+
+        changed_files4, _ = repo_tool.find_changed_files("HEAD", "HEAD~2")
+        assert len(changed_files4) == 2, changed_files4
+
+    def test_is_ancestor_of(
+        self, repo_root_path, git_repo, init_repo_with_models_factory, common_filepath
+    ):
+        init_repo_with_models_factory(1, is_multi=False)
+        repo_tool = GitTool(repo_root_path)
+        for index in range(1, 5):
+            make_a_change_and_commit(git_repo, [str(common_filepath)], index)
+            ancestor_ref = f"HEAD~{index}"
+            assert repo_tool.is_ancestor_of(ancestor_ref, "HEAD")
+
+    def test_merge_base_commit_sha(
+        self, repo_root_path, git_repo, init_repo_with_models_factory, common_filepath
+    ):
+        init_repo_with_models_factory(1, is_multi=False)
+
+        # 1. Create feature branch and checkout
+        feature_branch = git_repo.create_head("feature")
+        feature_branch.checkout()
+
+        # 2. Make some changes in the feature branch
+        for index in range(1, 4):
+            make_a_change_and_commit(git_repo, [str(common_filepath)], index)
+
+        head_sha = git_repo.head.commit.hexsha
+
+        repo_tool = GitTool(repo_root_path)
+        split_commit_sha = repo_tool.merge_base_commit_sha("master", head_sha)
+        assert split_commit_sha == git_repo.heads["master"].commit.hexsha


### PR DESCRIPTION
In a common workflow, when creating a pull request in GitHub, there's always a remote repository and the split commit (merge base) from the main branch should be examined against the remote main branch. 
On the other hand, when running the functional tests locally, there's no remote repository involved and therefore the split commit should be examined against a local main branch.