### PR TITLE
[RAPTOR-8438] Allow to execute a single functional test by a make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 
+FUNCTIONAL_TESTS ?= 'tests/functional'
+
 validate-env-%:
 	@if [ "${$*}" = "" ]; then \
 	  printf "\033[0;31m\nEnvironment variable '${*}' is not set. Aborting.\n\n\033[0m"; \
@@ -20,7 +22,8 @@ test-unit:
 .PHONY: test-unit
 
 test-functional: validate-env-DATAROBOT_WEBSERVER validate-env-DATAROBOT_API_TOKEN
-	set -ex; PYTHONPATH=.:src pytest -v --log-cli-level error ${FLAGS} tests/functional
+	set -ex; PYTHONPATH=.:src pytest -v --log-cli-level error ${FLAGS} ${FUNCTIONAL_TESTS}
+
 .PHONY: test
 
 black:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Allow a caller to execute a single functional test with the make command line. The default, if not provided, is execution of all the functional tests.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Improve the Makefile