### PR TITLE
[RAPTOR-8439] Remove the GitHub actions from the workflow and execute a single functional test instead

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Pull Request Workflow CI/CD
+name: Workflow CI/CD
 
 # Controls when the workflow will run
 on:
@@ -99,10 +99,30 @@ jobs:
       - name: Run unit-tests
         run: make test
 
+  run-functional-test:
+    needs: run-unit-tests
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - name: Install Reqruirements
+        run: pip install -r ${{ github.workspace }}/tests/requirements.txt
+
+      - name: Run a functional test
+        run: |
+          make test-functional \
+            FUNCTIONAL_TESTS='tests/functional/test_deployment_github_actions.py::TestDeploymentGitHubActions::test_e2e_deployment_create[push]'
+
   # This workflow contains a single job called "build"
   datarobot-custom-inference-model:
+    # Skip this job! It is an intermediate step towards putting it in a separate repository.
     # Run this job on any action of a PR, but skip the job upon merge to master
-    if: ${{ github.event.pull_request.merged != true }}
+    if: ${{ false && github.event.pull_request.merged != true }}
 
     needs: [validate-code-style, run-unit-tests]
 
@@ -152,6 +172,9 @@ jobs:
 
   datarobot-custom-inference-model-deployment:
     needs: [validate-code-style, run-unit-tests, datarobot-custom-inference-model]
+
+    # Skip this job! It is an intermediate step towards putting it in a separate repository.
+    if: ${{ false }}
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
This is an intermediate step towards putting the related GitHub actions in their own repositories.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Skip the related actions in the workflow
* Add a new job to the workflow to run the functional test
