### PR TITLE
[RAPTOR-8440] Prepare the actions for external usage

### DIFF
--- a/.github/actions/custom-inference-model-deployment/action.yml
+++ b/.github/actions/custom-inference-model-deployment/action.yml
@@ -39,7 +39,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - run: pip install -r ${GITHUB_ACTION_PATH}/../../src/requirements.txt
+    - run: pip install -r ${GITHUB_ACTION_PATH}/../../../src/requirements.txt
       shell: bash
     - id: custom-inference-model-deployment
       run: |
@@ -53,7 +53,7 @@ runs:
         else
         allow_deployment_deletion_arg=""
         fi
-        python ${GITHUB_ACTION_PATH}/../../src/main.py \
+        python ${GITHUB_ACTION_PATH}/../../../src/main.py \
           --deploy \
           --api-token ${{ inputs.api-token }} \
           --webserver ${{ inputs.webserver }} \

--- a/.github/actions/custom-inference-model/action.yml
+++ b/.github/actions/custom-inference-model/action.yml
@@ -42,7 +42,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - run: pip install -r ${GITHUB_ACTION_PATH}/../../src/requirements.txt
+    - run: pip install -r ${GITHUB_ACTION_PATH}/../../../src/requirements.txt
       shell: bash
     - id: custom-inference-model
       run: |
@@ -56,7 +56,7 @@ runs:
         else
           allow_model_deletion_arg=""
         fi
-        python ${GITHUB_ACTION_PATH}/../../src/main.py \
+        python ${GITHUB_ACTION_PATH}/../../../src/main.py \
           --api-token ${{ inputs.api-token }} \
           --webserver ${{ inputs.webserver }} \
           ${verify_cert_arg} \

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -155,7 +155,7 @@ jobs:
       - name: DataRobot Custom Inference Model
         id: custom-inference-model
         if: ${{ env.INSPECT_CONTEXT == 'false' }}
-        uses: ./actions/custom-inference-model
+        uses: ./.github/actions/custom-inference-model
         with:
           api-token: $DATAROBOT_API_TOKEN
           webserver: $DATAROBOT_WEBSERVER
@@ -205,7 +205,7 @@ jobs:
       - name: DataRobot Custom Inference Model Deployment
         id: custom-inference-model-deployment
         if: ${{ env.INSPECT_CONTEXT == 'false' }}
-        uses: ./actions/custom-inference-model-deployment
+        uses: ./.github/actions/custom-inference-model-deployment
         with:
           api-token: $DATAROBOT_API_TOKEN
           webserver: $DATAROBOT_WEBSERVER


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
The idea is to allow other actions to use the actions from this repository. The other actions will be published in the marketplace and will be exposed as "Custom Inference Model" and "Custom Inference Model Deployment" actions.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Move the action definitions under `.github`, as recommended by GitHub
* Execute the actions as part of the workflow