### PR TITLE
[RAPTOR-8466] Dispose of the input argument root_dir and rename all related attributes

### DIFF
--- a/src/common/github_env.py
+++ b/src/common/github_env.py
@@ -6,6 +6,7 @@
 """A module to provide an interface to GitHub environment variables"""
 
 import os
+from pathlib import Path
 
 
 class GitHubEnv:
@@ -52,4 +53,11 @@ class GitHubEnv:
     @staticmethod
     def base_ref():
         """The name of the base ref or target branch of the pull request in a workflow run.o"""
+
         return os.environ.get("GITHUB_BASE_REF")
+
+    @staticmethod
+    def workspace_path():
+        """The default location of the repository when using the checkout action."""
+
+        return Path(os.environ.get("GITHUB_WORKSPACE"))

--- a/src/custom_inference_model.py
+++ b/src/custom_inference_model.py
@@ -26,7 +26,7 @@ class CustomInferenceModelAction:
 
     def __init__(self, options):
         self._options = options
-        self._repo = GitTool(options.root_dir)
+        self._repo = GitTool(GitHubEnv.workspace_path())
         self._model_controller = ModelController(options, self._repo)
         self._deployment_controller = None
 

--- a/src/main.py
+++ b/src/main.py
@@ -44,7 +44,6 @@ def argparse_options(args=None):
     parser.add_argument(
         "--branch", required=True, help="The branch against which the program will function."
     )
-    parser.add_argument("--root-dir", required=True, help="The workspace root directory.")
     parser.add_argument(
         "--allow-model-deletion",
         action="store_true",

--- a/src/model_file_path.py
+++ b/src/model_file_path.py
@@ -29,7 +29,7 @@ class ModelFilePath:
         MODEL = 1
         ROOT = 2
 
-    def __init__(self, raw_file_path, model_root_dir, repo_root_dir):
+    def __init__(self, raw_file_path, model_root_dir, workspace_path):
         self._raw_file_path = raw_file_path
         self._filepath = Path(raw_file_path)
         # It is important to have an indication about the path origin and the relation to
@@ -37,13 +37,13 @@ class ModelFilePath:
         # or it is supposed to be copied into it. This will help us to detect collisions
         # between paths that exist under the model versus those that are supposed to be copied.
         path_under_model, relative_to = self.get_path_under_model(
-            self._filepath, model_root_dir, repo_root_dir
+            self._filepath, model_root_dir, workspace_path
         )
         self._under_model = path_under_model
         self._relative_to = relative_to
 
     @classmethod
-    def get_path_under_model(cls, filepath, model_root_dir, repo_root_dir):
+    def get_path_under_model(cls, filepath, model_root_dir, workspace_path):
         """
         Returns the relative file path of a given model's file from the model's root directory.
 
@@ -53,7 +53,7 @@ class ModelFilePath:
             A model's file path.
         model_root_dir : pathlib.Path
             The model's root directory.
-        repo_root_dir : pathlib.Path
+        workspace_path : pathlib.Path
             The repository root directory.
 
         Returns
@@ -68,7 +68,9 @@ class ModelFilePath:
             relative_to = cls.RelativeTo.MODEL
         except ValueError:
             try:
-                path_under_model = cls._get_path_under_model_for_given_root(filepath, repo_root_dir)
+                path_under_model = cls._get_path_under_model_for_given_root(
+                    filepath, workspace_path
+                )
                 relative_to = cls.RelativeTo.ROOT
             except ValueError as ex:
                 raise PathOutsideTheRepository(

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -114,7 +114,7 @@ class ModelInfo:
         """Returns whether the main program file path exists or not"""
         return self.main_program_filepath() is not None
 
-    def set_model_paths(self, paths, repo_root_path):
+    def set_model_paths(self, paths, workspace_path):
         """
         Builds a dictionary of the files belong to the given model. The key is a resolved
         file path of a given file and the value is a ModelFilePath of that same file.
@@ -123,14 +123,14 @@ class ModelInfo:
         ----------
         paths : list
             A list of file paths associated with the given model.
-        repo_root_path : pathlib.Path
+        workspace_path : pathlib.Path
             The repository root directory.
         """
 
         logger.debug("Model %s is set with the following paths: %s", self.user_provided_id, paths)
         self._model_file_paths = {}
         for path in paths:
-            model_filepath = ModelFilePath(path, self.model_path, repo_root_path)
+            model_filepath = ModelFilePath(path, self.model_path, workspace_path)
             self._model_file_paths[model_filepath.resolved] = model_filepath
 
     def paths_under_model_by_relative(self, relative_to):

--- a/tests/functional/test_model_github_actions.py
+++ b/tests/functional/test_model_github_actions.py
@@ -35,12 +35,12 @@ from tests.functional.conftest import webserver_accessible
 
 
 @pytest.fixture
-def cleanup(dr_client, repo_root_path):
+def cleanup(dr_client, workspace_path):
     """A fixture to delete models in DataRobot that were created from the local source tree."""
 
     yield
 
-    cleanup_models(dr_client, repo_root_path)
+    cleanup_models(dr_client, workspace_path)
 
 
 @pytest.mark.skipif(not webserver_accessible(), reason="DataRobot webserver is not accessible.")
@@ -73,7 +73,7 @@ class TestModelGitHubActions:
     def test_e2e_pull_request_event_with_multiple_changes(  # pylint: disable=too-many-locals
         self,
         dr_client,
-        repo_root_path,
+        workspace_path,
         git_repo,
         model_metadata,
         model_metadata_yaml_file,
@@ -93,7 +93,7 @@ class TestModelGitHubActions:
             checks,
             feature_branch,
             git_repo,
-            repo_root_path,
+            workspace_path,
             main_branch_name,
             model_metadata,
             model_metadata_yaml_file,
@@ -102,7 +102,7 @@ class TestModelGitHubActions:
         )
         self._run_github_action_with_testing_enabled(
             dr_client,
-            repo_root_path,
+            workspace_path,
             git_repo,
             main_branch_name,
             model_metadata,
@@ -116,7 +116,7 @@ class TestModelGitHubActions:
         checks,
         feature_branch,
         git_repo,
-        repo_root_path,
+        workspace_path,
         main_branch_name,
         model_metadata,
         model_metadata_yaml_file,
@@ -146,7 +146,7 @@ class TestModelGitHubActions:
                 # Run GitHub pull request action
                 printout("Run custom model GitHub action (pull-request)...")
                 run_github_action(
-                    repo_root_path,
+                    workspace_path,
                     git_repo,
                     main_branch_name,
                     event_name="pull_request",
@@ -232,7 +232,7 @@ class TestModelGitHubActions:
     def _run_github_action_with_testing_enabled(
         cls,
         dr_client,
-        repo_root_path,
+        workspace_path,
         git_repo,
         main_branch_name,
         model_metadata,
@@ -240,7 +240,7 @@ class TestModelGitHubActions:
     ):
         printout("Run custom model GitHub action (push event) with testing ...")
         with cls.enable_custom_model_testing(model_metadata_yaml_file):
-            run_github_action(repo_root_path, git_repo, main_branch_name, "push", is_deploy=False)
+            run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
 
         custom_model = dr_client.fetch_custom_model_by_git_id(
             model_metadata[ModelSchema.MODEL_ID_KEY]
@@ -253,7 +253,7 @@ class TestModelGitHubActions:
     def test_e2e_pull_request_event_with_model_deletion(
         self,
         dr_client,
-        repo_root_path,
+        workspace_path,
         git_repo,
         model_metadata,
         model_metadata_yaml_file,
@@ -279,7 +279,7 @@ class TestModelGitHubActions:
             checks,
             feature_branch,
             git_repo,
-            repo_root_path,
+            workspace_path,
             main_branch_name,
             model_metadata,
             model_metadata_yaml_file,
@@ -288,7 +288,7 @@ class TestModelGitHubActions:
         )
 
         printout("Run custom model GitHub action (push event) ...")
-        run_github_action(repo_root_path, git_repo, main_branch_name, "push", is_deploy=False)
+        run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
 
         # 12. Validation. The model is actually deleted only upon merging.
         printout("Validate after merging ...")
@@ -312,7 +312,7 @@ class TestModelGitHubActions:
 
     @pytest.mark.usefixtures("cleanup")
     def test_e2e_push_event_with_multiple_changes(
-        self, repo_root_path, git_repo, model_metadata_yaml_file, main_branch_name
+        self, workspace_path, git_repo, model_metadata_yaml_file, main_branch_name
     ):
         """
         An end-to-end case to test a push event with multiple commits, by the custom
@@ -330,7 +330,7 @@ class TestModelGitHubActions:
 
             # 3. Run GitHub pull request action
             printout("Run custom model GitHub action (push event) ...")
-            run_github_action(repo_root_path, git_repo, main_branch_name, "push", is_deploy=False)
+            run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
         printout("Done")
 
     def test_is_accessible(self):
@@ -342,7 +342,7 @@ class TestModelGitHubActions:
     def test_e2e_set_training_and_holdout_datasets_for_structured_model(
         self,
         dr_client,
-        repo_root_path,
+        workspace_path,
         git_repo,
         model_metadata,
         model_metadata_yaml_file,
@@ -358,7 +358,7 @@ class TestModelGitHubActions:
             "Create a custom model as a preliminary requirement. "
             "Run custom model GitHub action (push event) ..."
         )
-        run_github_action(repo_root_path, git_repo, main_branch_name, "push", is_deploy=False)
+        run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
 
         with temporarily_upload_training_dataset_for_structured_model(
             dr_client, model_metadata_yaml_file, event_name="push"
@@ -369,7 +369,7 @@ class TestModelGitHubActions:
 
                 printout("Run custom inference models GitHub action ...")
                 run_github_action(
-                    repo_root_path, git_repo, main_branch_name, "push", is_deploy=False
+                    workspace_path, git_repo, main_branch_name, "push", is_deploy=False
                 )
 
                 # Validate
@@ -378,7 +378,7 @@ class TestModelGitHubActions:
                 assert custom_model["trainingDatasetId"] == training_dataset_id
                 assert custom_model["trainingDataPartitionColumn"] == partition_column
             finally:
-                cleanup_models(dr_client, repo_root_path)
+                cleanup_models(dr_client, workspace_path)
 
         printout("Done")
 
@@ -386,7 +386,7 @@ class TestModelGitHubActions:
     def test_e2e_set_training_and_holdout_datasets_for_unstructured_model(
         self,
         dr_client,
-        repo_root_path,
+        workspace_path,
         git_repo,
         model_metadata,
         model_metadata_yaml_file,
@@ -407,7 +407,7 @@ class TestModelGitHubActions:
                 "Create a custom model as a preliminary requirement. "
                 "Run custom model GitHub action (push event) ..."
             )
-            run_github_action(repo_root_path, git_repo, main_branch_name, "push", is_deploy=False)
+            run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
 
             user_provided_id = ModelSchema.get_value(model_metadata, ModelSchema.MODEL_ID_KEY)
 
@@ -436,7 +436,7 @@ class TestModelGitHubActions:
 
                     printout("Run custom inference models GitHub action ...")
                     run_github_action(
-                        repo_root_path, git_repo, main_branch_name, "push", is_deploy=False
+                        workspace_path, git_repo, main_branch_name, "push", is_deploy=False
                     )
 
                     # Validation
@@ -450,7 +450,7 @@ class TestModelGitHubActions:
                         == holdout_dataset_id
                     )
                 finally:
-                    cleanup_models(dr_client, repo_root_path)
+                    cleanup_models(dr_client, workspace_path)
 
         printout("Done")
 
@@ -458,7 +458,7 @@ class TestModelGitHubActions:
     def test_e2e_update_model_settings(
         self,
         dr_client,
-        repo_root_path,
+        workspace_path,
         git_repo,
         model_metadata,
         model_metadata_yaml_file,
@@ -476,7 +476,7 @@ class TestModelGitHubActions:
             "Create a custom model as a preliminary requirement. "
             "Run custom model GitHub action (push event) ..."
         )
-        run_github_action(repo_root_path, git_repo, main_branch_name, "push", is_deploy=False)
+        run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
 
         unique_string = unique_str()
         for settings_key, desired_settings_value in [
@@ -504,7 +504,7 @@ class TestModelGitHubActions:
 
                 printout("Run custom inference models GitHub action (push) ...")
                 run_github_action(
-                    repo_root_path, git_repo, main_branch_name, "push", is_deploy=False
+                    workspace_path, git_repo, main_branch_name, "push", is_deploy=False
                 )
 
                 # Validate

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -40,7 +40,7 @@ class TestGitTool:
     """Contains Git tool unit-tests."""
 
     def test_changed_files_between_commits(
-        self, git_repo, repo_root_path, init_repo_with_models_factory, common_filepath
+        self, git_repo, workspace_path, init_repo_with_models_factory, common_filepath
     ):
         """Test changed files between commits."""
 
@@ -48,13 +48,13 @@ class TestGitTool:
 
         make_a_change_and_commit(git_repo, [str(common_filepath)], 1)
 
-        first_model_main_program_filepath = repo_root_path / "model_0" / "custom.py"
+        first_model_main_program_filepath = workspace_path / "model_0" / "custom.py"
         assert first_model_main_program_filepath.is_file()
         make_a_change_and_commit(
             git_repo, [str(common_filepath), first_model_main_program_filepath], 2
         )
 
-        repo_tool = GitTool(repo_root_path)
+        repo_tool = GitTool(workspace_path)
         changed_files1, deleted_files = repo_tool.find_changed_files("HEAD")
         assert len(changed_files1) == 2, changed_files1
         assert not deleted_files
@@ -69,19 +69,19 @@ class TestGitTool:
         assert len(changed_files4) == 2, changed_files4
 
     def test_is_ancestor_of(
-        self, repo_root_path, git_repo, init_repo_with_models_factory, common_filepath
+        self, workspace_path, git_repo, init_repo_with_models_factory, common_filepath
     ):
         """Test the check for commit ancestor."""
 
         init_repo_with_models_factory(1, is_multi=False)
-        repo_tool = GitTool(repo_root_path)
+        repo_tool = GitTool(workspace_path)
         for index in range(1, 5):
             make_a_change_and_commit(git_repo, [str(common_filepath)], index)
             ancestor_ref = f"HEAD~{index}"
             assert repo_tool.is_ancestor_of(ancestor_ref, "HEAD")
 
     def test_merge_base_commit_sha(
-        self, repo_root_path, git_repo, init_repo_with_models_factory, common_filepath
+        self, workspace_path, git_repo, init_repo_with_models_factory, common_filepath
     ):
         """Test the merge base commit sha."""
 
@@ -97,6 +97,6 @@ class TestGitTool:
 
         head_sha = git_repo.head.commit.hexsha
 
-        repo_tool = GitTool(repo_root_path)
+        repo_tool = GitTool(workspace_path)
         split_commit_sha = repo_tool.merge_base_commit_sha("master", head_sha)
         assert split_commit_sha == git_repo.heads["master"].commit.hexsha

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -410,7 +410,7 @@ class TestCustomModelVersionRoutes:
         pull_request_commit_sha,
         single_model_file_paths,
         single_model_root_path,
-        repo_root_path,
+        workspace_path,
     ):
         """A case to test a full payload setup when creating a custom model version."""
 
@@ -418,7 +418,7 @@ class TestCustomModelVersionRoutes:
         try:
             regression_model_info._model_path = single_model_root_path
             changed_files_info = [
-                ModelFilePath(p, regression_model_info.model_path, repo_root_path)
+                ModelFilePath(p, regression_model_info.model_path, workspace_path)
                 for p in single_model_file_paths
             ]
             payload, file_objs = DrClient._setup_payload_for_custom_model_version_creation(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
In order to comply with other GitHub environment attributes, the root workspace path should be read from such environment variable instead of getting it as input argument.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Get rid of the input argument `--root-dir`
* Read the `GITHUB_WORKSPACE` environment variable to get the repository working path
* Rename all related attributes and methods