### PR TITLE
[RAPTOR-8483] Update the main branch sha on a push event for affected models

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -289,7 +289,7 @@ class DrClient:
         ----------
         custom_model_id : str
             A custom model ID
-        custom_model_version_id :
+        custom_model_version_id : str
             A custom model version ID
 
         Returns
@@ -488,6 +488,43 @@ class DrClient:
             payload.append(("filesToDelete", file_id_to_delete))
 
         return file_objs
+
+    def update_custom_model_version_main_branch_commit_sha(
+        self, datarobot_custom_model_version, commit_sha
+    ):
+        """
+        Update a given custom inference model version main branch commit SHA.
+
+        Parameters
+        ----------
+        datarobot_custom_model_version : dict
+            A DataRobot custom model version entity.
+        commit_sha: str
+            The main branch commit SHA
+
+        Returns
+        -------
+        dict,
+            A DataRobot custom model version
+        """
+
+        git_model_version = datarobot_custom_model_version["gitModelVersion"]
+        git_model_version["mainBranchCommitSha"] = commit_sha
+        payload = {"gitModelVersion": git_model_version}
+
+        url = self.CUSTOM_MODELS_VERSION_ROUTE.format(
+            model_id=datarobot_custom_model_version["customModelId"],
+            model_ver_id=datarobot_custom_model_version["id"],
+        )
+        response = self._http_requester.patch(url, json=payload)
+        if response.status_code != 200:
+            raise DataRobotClientError(
+                f"Failed to update custom model version main branch commit SHA. "
+                f"Response status: {response.status_code} "
+                f"Response body: {response.text}",
+                code=response.status_code,
+            )
+        return response.json()
 
     def delete_custom_model_by_model_id(self, custom_model_id):
         """
@@ -1270,7 +1307,7 @@ class DrClient:
         response = self._http_requester.post(url, json=payload)
         if response.status_code != 202:
             raise DataRobotClientError(
-                "Failed to submit a challenger."
+                "Failed to submit a challenger. "
                 f"Response status: {response.status_code} "
                 f"Response body: {response.text}",
             )

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -519,6 +519,15 @@ class ModelController(ControllerBase):
                         custom_model_id,
                         latest_version["id"],
                     )
+                else:
+                    # If the model was somehow affected by the given event, make sure to update the
+                    # main branch commit SHA. This solves an issue of follow-up pull requests,
+                    # which are not related to the given model that should not affect the given
+                    # model.
+                    if GitHubEnv.is_push():
+                        self._dr_client.update_custom_model_version_main_branch_commit_sha(
+                            latest_version, GitHubEnv.github_sha()
+                        )
 
                 if model_info.flags.should_update_settings:
                     self._update_settings(custom_model, model_info)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Update the main branch commit SHA on a push event even if no new version is created, but the model is considered as affected by the push event.

This solves an issue of follow-up changes, which are not related to the given model, thus no changes should be referred to this model.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add new method to the DataRobot client to update the main branch commit sha
* Make sure to update the main branch sha when a model is affected without a new version