### PR TITLE
[RAPTOR-8535] Handle properly empty yaml files

### DIFF
--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -111,7 +111,11 @@ class ControllerBase(ABC):
         yaml_files.extend(glob(f"{self._workspace_path}/**/*.yml", recursive=True))
         for yaml_path in yaml_files:
             with open(yaml_path, encoding="utf-8") as fd:
-                yield yaml_path, yaml.safe_load(fd)
+                yaml_content = yaml.safe_load(fd)
+                if not yaml_content:
+                    logger.warning("Detected an invalid or empty yaml file: %s", yaml_path)
+                else:
+                    yield yaml_path, yaml_content
 
     def _to_absolute(self, path, parent):
         match = re.match(r"^(/|\$ROOT/)", path)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -192,10 +192,12 @@ def fixture_single_model_factory(workspace_path, common_path_with_code):
                 "./README.md"
             ]
 
+        metadata_yaml_filepath = None
         if write_metadata:
-            write_to_file(model_path / "model.yaml", yaml.dump(single_model_metadata))
+            metadata_yaml_filepath = model_path / "model.yaml"
+            write_to_file(metadata_yaml_filepath, yaml.dump(single_model_metadata))
 
-        return single_model_metadata
+        return single_model_metadata, metadata_yaml_filepath
 
     yield _inner
 
@@ -215,7 +217,7 @@ def fixture_models_factory(workspace_path, single_model_factory):
         models_metadata = []
         for counter in range(num_models):
             model_name = f"model_multi_{counter}" if is_multi else f"model_{counter}"
-            model_metadata = single_model_factory(
+            model_metadata, _ = single_model_factory(
                 model_name,
                 write_metadata=not is_multi,
                 with_include_glob=with_include_glob,

--- a/tests/unit/test_custom_inference_model.py
+++ b/tests/unit/test_custom_inference_model.py
@@ -51,6 +51,17 @@ class TestCustomInferenceModel:
         model_controller.scan_and_load_models_metadata()
         assert len(model_controller.models_info) == 0
 
+    def test_scan_and_load_models_empty_yaml_definition(self, options, single_model_factory):
+        """Test models' scanning and loading of empty yaml file."""
+
+        name = "model-1"
+        _, model_yaml_filepath = single_model_factory(name, write_metadata=True)
+        with open(model_yaml_filepath, "w", encoding="utf-8") as fd:
+            fd.write("")
+        model_controller = ModelController(options, None)
+        model_controller.scan_and_load_models_metadata()
+        assert len(model_controller.models_info) == 0
+
     @pytest.mark.parametrize("num_models", [1, 2, 3])
     def test_scan_and_load_models_from_multi_separate_yaml_files(
         self, options, single_model_factory, num_models


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
If by mistake there's an empty yaml file in the repository, the action will fail with misleading error. The desired functionality is to skip such files and print a proper warning.


## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Detect an empty yaml files during loading and print a warning message
* Unit-tests
