### PR TITLE
[RAPTOR-8538] Make directory path in the glob related fields recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,11 @@ test:
       total_prediction_requests: 50
 ```
 
+**NOTE**: the patterns used in the `exclude_glob_pattern` & `include_glob_pattern` fields are an
+extension to the common glob rules. A path that ends with `/` (slash), which means a directory,
+will automatically be regarded as suffixed with `**`. This means that the directory will be
+scanned recursively.
+
 ##### A Multi Models Definition
 Here is an example of a multi-models definition, which includes only mandatory fields:
 

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -117,6 +117,10 @@ class ControllerBase(ABC):
                 else:
                     yield yaml_path, yaml_content
 
+    @staticmethod
+    def _make_directory_pattern_recursive(pattern):
+        return f"{pattern}**" if pattern.endswith("/") else pattern
+
     def _to_absolute(self, path, parent):
         match = re.match(r"^(/|\$ROOT/)", path)
         if match:
@@ -220,6 +224,9 @@ class ModelController(ControllerBase):
             included_paths = set([])
             if include_glob_patterns:
                 for include_glob_pattern in include_glob_patterns:
+                    include_glob_pattern = self._make_directory_pattern_recursive(
+                        include_glob_pattern
+                    )
                     include_glob_pattern = self._to_absolute(
                         include_glob_pattern, model_info.model_path
                     )
@@ -232,6 +239,7 @@ class ModelController(ControllerBase):
                 ModelSchema.EXCLUDE_GLOB_KEY
             ]
             for exclude_glob_pattern in exclude_glob_patterns:
+                exclude_glob_pattern = self._make_directory_pattern_recursive(exclude_glob_pattern)
                 exclude_glob_pattern = self._to_absolute(
                     exclude_glob_pattern, model_info.model_path
                 )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -183,8 +183,8 @@ def fixture_single_model_factory(workspace_path, common_path_with_code):
         if with_include_glob:
             # noinspection PyTypeChecker
             single_model_metadata[ModelSchema.VERSION_KEY][ModelSchema.INCLUDE_GLOB_KEY] = [
-                "./**",
-                f"/{common_path_with_code.relative_to(workspace_path)}/**",
+                "./",
+                f"/{common_path_with_code.relative_to(workspace_path)}/",
             ]
         if with_exclude_glob:
             # noinspection PyTypeChecker


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
The common glob patterns enable specifying directories on their own, thus only the directory will be included. It has no real meaning in the case of custom inference models - directories are not included, but only files within directories. Therefore, it is required to automatically regard directory paths that are provided by users as being scanned recursively, for both include and exclude patterns.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Automatically add `**` to paths in the glob pattern lists that ends with `/`
* Unit-tests
