### PR TITLE
[RAPTOR-8723] Fix deprecating set-output command

### DIFF
--- a/src/common/github_env.py
+++ b/src/common/github_env.py
@@ -61,3 +61,15 @@ class GitHubEnv:
         """The default location of the repository when using the checkout action."""
 
         return Path(os.environ.get("GITHUB_WORKSPACE"))
+
+    @staticmethod
+    def github_output():
+        """The GitHub output environment variable that holds output parameter values."""
+
+        return os.environ.get("GITHUB_OUTPUT", "")
+
+    @classmethod
+    def set_output_param(cls, name, value):
+        """Set an output parameter that can be referenced by a follow-up step."""
+
+        os.environ["GITHUB_OUTPUT"] = f"{cls.github_output()}{name}={value}\n"

--- a/src/custom_models_action.py
+++ b/src/custom_models_action.py
@@ -78,7 +78,7 @@ class CustomModelsAction:
                 self.model_controller.handle_deleted_models()
 
         finally:
-            self._print_statistics()
+            self._save_statistics()
 
     def _prerequisites(self):
         """Check prerequisites before execution."""
@@ -124,7 +124,7 @@ class CustomModelsAction:
                 return False
         return True
 
-    def _print_statistics(self):
-        self.model_controller.print_statistics()
+    def _save_statistics(self):
+        self.model_controller.save_statistics()
         if self.deployment_controller:
-            self.deployment_controller.print_statistics()
+            self.deployment_controller.save_statistics()

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ import os
 import sys
 
 from common.exceptions import GenericException
+from common.github_env import GitHubEnv
 from custom_models_action import CustomModelsAction
 
 logger = logging.getLogger()
@@ -103,9 +104,8 @@ def main(args=None):
 
     try:
         CustomModelsAction(options).run()
-        print(
-            "::set-output name=message::"
-            "Custom inference model GitHub action completed with success.\n"
+        GitHubEnv.set_output_param(
+            "message", "Custom inference model GitHub action completed with success."
         )
     except GenericException as ex:
         # Avoid printing the stacktrace

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -58,22 +58,15 @@ class ControllerBase(ABC):
         total_deleted: int = 0
         total_created_versions: int = 0
 
-        def print(self, label):
-            """
-            Print the statistics to the standard output. This is how the GitHub action
-            exposes statistics to other steps in the workflow.
-            """
+        def save(self, label):
+            """Save the statistics to the GitHub environment."""
 
-            print(
-                f"""
-                ::set-output name=total-affected-{label}::{self.total_affected}
-                ::set-output name=total-created-{label}::{self.total_created}
-                ::set-output name=total-deleted-{label}::{self.total_deleted}
-                """
-            )
+            GitHubEnv.set_output_param(f"total-affected-{label}", self.total_affected)
+            GitHubEnv.set_output_param(f"total-created-{label}", self.total_created)
+            GitHubEnv.set_output_param(f"total-deleted-{label}", self.total_deleted)
             if label == ControllerBase.MODELS_LABEL:
-                print(
-                    f"::set-output name=total-created-model-versions::{self.total_created_versions}"
+                GitHubEnv.set_output_param(
+                    "total-created-model-versions", self.total_created_versions
                 )
 
     def __init__(self, options, repo):
@@ -130,9 +123,10 @@ class ControllerBase(ABC):
             path = f"{parent}/{path}"
         return path
 
-    def print_statistics(self):
-        """Print the statistics that are configured by the GitHub action to the standard output."""
-        self.stats.print(self._label())
+    def save_statistics(self):
+        """Save the statistics that are configured by the GitHub action."""
+
+        self.stats.save(self._label())
 
     @abstractmethod
     def _label(self):

--- a/tests/unit/test_custom_inference_model.py
+++ b/tests/unit/test_custom_inference_model.py
@@ -191,6 +191,30 @@ class TestCustomInferenceModel:
             )
             assert num_affected_models == reference
 
+    @pytest.mark.usefixtures("no_models")
+    def test_save_statistics(self, options):
+        """A case to test custom inference model's statistics saving."""
+
+        with patch("dr_client.DrClient"):
+            model_controller = ModelController(options, repo=None)
+
+            label = ModelController.MODELS_LABEL
+            model_controller._stats.save(label)
+            for param in ["total-affected", "total-created", "total-created"]:
+                assert f"{param}-{label}=0\n" in GitHubEnv.github_output()
+            assert "total-created-model-versions=0\n" in GitHubEnv.github_output()
+
+            desired_value = 5
+            for param in ["total_affected", "total_created", "total_created"]:
+                setattr(model_controller._stats, param, desired_value)
+            setattr(model_controller._stats, "total_created_versions", desired_value)
+
+            model_controller._stats.save(label)
+
+            for param in ["total-affected", "total-created", "total-created"]:
+                assert f"{param}-{label}={desired_value}\n" in GitHubEnv.github_output()
+            assert f"total-created-model-versions={desired_value}\n" in GitHubEnv.github_output()
+
 
 class TestCustomInferenceModelDeletion:
     """Contains unit-tests for model deletion."""


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## CHANGES
* Fix the way an output parameter is set.
