### PR TITLE
[RAPTOR-8736] Fix unit-tests that access GITHUB_OUTPUT to save statistics

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -465,11 +465,14 @@ def github_output():
     existing output file.
     """
 
-    github_output_filepath = Path("/tmp/github_output")
     prev_github_output = os.environ.get("GITHUB_OUTPUT")
+    github_output_filepath = Path("/tmp/github_output")
     with open(github_output_filepath, "w", encoding="utf-8"), patch.dict(
         os.environ, {"GITHUB_OUTPUT": str(github_output_filepath)}
     ):
         yield github_output_filepath
     os.remove(github_output_filepath)
-    os.environ["GITHUB_OUTPUT"] = prev_github_output
+    if prev_github_output is None:
+        os.environ.pop("GITHUB_OUTPUT", None)
+    else:
+        os.environ["GITHUB_OUTPUT"] = prev_github_output

--- a/tests/unit/test_custom_inference_model.py
+++ b/tests/unit/test_custom_inference_model.py
@@ -375,7 +375,7 @@ class TestCustomInferenceModelDeletion:
 class TestGlobPatterns:
     """Contains unit-test for glob patters."""
 
-    @pytest.mark.usefixtures("common_path_with_code")
+    @pytest.mark.usefixtures("common_path_with_code", "github_output")
     @pytest.mark.parametrize("num_models", [1, 2, 3])
     @pytest.mark.parametrize("is_multi", [True, False], ids=["multi", "single"])
     @pytest.mark.parametrize(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
The issue apply to local development environment only, where the GITHUB_OUTPUT environment variable does not exist in the environment.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
