### PR TITLE
[RAPTOR-8802] Wait for a deployment creation completion before update its settings

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -87,7 +87,7 @@ class DrClient:
 
         self._http_requester = HttpRequester(datarobot_webserver, datarobot_api_token, verify_cert)
 
-    def _wait_for_async_resolution(self, async_location, max_wait=600, return_on_completed=False):
+    def _wait_for_async_resolution(self, async_location, max_wait=600, return_on_completed=True):
         start_time = time.time()
 
         while time.time() < start_time + max_wait:
@@ -1027,6 +1027,8 @@ class DrClient:
                 f"Response body: {response.text}",
                 code=response.status_code,
             )
+        location = self._wait_for_async_resolution(response.headers["Location"])
+        response = self._http_requester.get(location, raw=True)
         return response.json()["id"]
 
     def _get_prediction_environment_id(self, model_package, deployment_info):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
It turns out to be much more robust to wait for a deployment creation completion before trying to configure certain settings in it.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add a method to wait for deployment creation completion before returning.