### PR TITLE
Add global setup fixture to cleanup leftover deployments and models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ test-functional-basic: validate-env-DATAROBOT_WEBSERVER validate-env-DATAROBOT_A
 	-v \
 	--log-cli-level error \
 	${FLAGS} \
-	tests/functional/test_deployment_github_actions.py\
-	::TestDeploymentGitHubActions::test_e2e_deployment_create
+	tests/functional/test_deployment_github_actions.py::TestDeploymentGitHubActions::test_e2e_deployment_create
 .PHONY: test-functional-basic
 
 black:

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -640,6 +640,16 @@ class DrClient:
             datarobot_custom_model_version["id"],
         )
 
+    def delete_all_custom_models(self, return_on_error=True):
+        """Delete all the custom models that are accessed by the user in DataRobot."""
+
+        for custom_model in self.fetch_custom_models():
+            try:
+                self.delete_custom_model_by_model_id(custom_model["id"])
+            except DataRobotClientError:
+                if return_on_error:
+                    raise
+
     def delete_custom_model_by_model_id(self, custom_model_id):
         """
         Delete a custom model in DataRobot, given a DataRobot model ID.
@@ -1302,6 +1312,16 @@ class DrClient:
                 f"Failed to update deployment label. Error: {response.text}.",
                 code=response.status_code,
             )
+
+    def delete_all_deployments(self, return_on_error=True):
+        """Delete all the deployments that are accessed by the user in DataRobot."""
+
+        for deployment in self.fetch_deployments():
+            try:
+                self.delete_deployment_by_id(deployment["id"])
+            except DataRobotClientError:
+                if return_on_error:
+                    raise
 
     def delete_deployment_by_id(self, deployment_id):
         """


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
If functional tests are stopped in the middle, there might be remainders in DataRobot account, which will never be tracked. It is essential to clear them up before starting a new session of functional tests.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add new methods in DrClient to delete all deployments and models
* Add new global fixture with a session scope and auto use, which will be called to cleanup deployments and models