### PR TITLE
Avoid concurrent runs of the action's workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,6 +12,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   LOGLEVEL: debug
   DATAROBOT_API_TOKEN: ${{ secrets.DATAROBOT_API_TOKEN }}  # Required by the functional tests


### PR DESCRIPTION
The functional tests in the workflow cannot be executed in parallel, because they work against the same account, but on different ad-hoc workspace tress.


# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
The functional tests in the workflow cannot be executed in parallel, because they work against the same account, but on different ad-hoc workspace tress.

Also, make sure to stop any previous run instead of waiting it to complete. This is useful if a fix was submitted before the previous run was completed.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add a concurrency limitation in the workflow YAML file
