### PR TITLE
[RAPTOR-8794] Fix a failure in 'test_e2e_deployment_settings' functional test when executing in GitHub

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -748,7 +748,8 @@ class DrClient:
             raise DataRobotClientError(
                 "Custom model version test failed. "
                 f"Response code: {response.status_code}. "
-                f"Response body: {response.text}.",
+                f"Response body: {response.text}. "
+                f"Request payload: {payload}.",
                 code=response.status_code,
             )
         return response

--- a/tests/functional/test_model_github_actions.py
+++ b/tests/functional/test_model_github_actions.py
@@ -46,7 +46,7 @@ def cleanup(dr_client, workspace_path):
 
 
 @pytest.mark.skipif(not webserver_accessible(), reason="DataRobot webserver is not accessible.")
-@pytest.mark.usefixtures("build_repo_for_testing", "set_model_dataset_for_testing")
+@pytest.mark.usefixtures("build_repo_for_testing", "set_model_dataset_for_testing", "github_output")
 class TestModelGitHubActions:
     """Contains an end-to-end test cases for the custom inference model GitHub action."""
 
@@ -597,7 +597,7 @@ class TestModelGitHubActions:
         yield requests_filepath
         os.remove(requests_filepath)
 
-    @pytest.mark.usefixtures("cleanup", "skip_model_testing", "github_output")
+    @pytest.mark.usefixtures("cleanup", "skip_model_testing")
     def test_e2e_model_version_with_dependency(
         self,
         dr_client,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
When trying to run all the functional tests as part of the workflow in GitHub, the `test_e2e_deployment_settings` was failing.  

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add necessary cleanup fixtures
* Add necessary setup fixtures
