### PR TITLE
[RAPTOR-8789] Fix stability check passing rate attribute value

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -823,7 +823,7 @@ class DrClient:
         if ModelSchema.TOTAL_PREDICTION_REQUESTS_KEY in info:
             check_params["numPredictions"] = info[ModelSchema.TOTAL_PREDICTION_REQUESTS_KEY]
         if ModelSchema.PASSING_RATE_KEY in info:
-            check_params["passingRate"] = info[ModelSchema.PASSING_RATE_KEY]
+            check_params["passingRate"] = info[ModelSchema.PASSING_RATE_KEY] / 100
         if ModelSchema.NUMBER_OF_PARALLEL_USERS_KEY in info:
             check_params["numParallelUsers"] = info[ModelSchema.NUMBER_OF_PARALLEL_USERS_KEY]
         if ModelSchema.MINIMUM_PAYLOAD_SIZE_KEY in info:

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -622,6 +622,16 @@ class TestCustomModelVersionRoutes:
 
             assert mock_full_custom_model_checks.keys() == DrApiAttrs.DR_TEST_CHECK_MAP.keys()
             parameters = DrClient._build_tests_parameters(mock_full_custom_model_checks)
+            dr_stability_check_key = DrApiAttrs.to_dr_test_check(ModelSchema.STABILITY_KEY)
+
+            assert (
+                parameters[dr_stability_check_key]["passingRate"]
+                == mock_full_custom_model_checks[ModelSchema.STABILITY_KEY][
+                    ModelSchema.PASSING_RATE_KEY
+                ]
+                / 100
+            )
+
             for check in [
                 ModelSchema.PREDICTION_VERIFICATION_KEY,
                 ModelSchema.PERFORMANCE_KEY,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
When setting stability checks, the passing_rate param we have on our example, has the value set to 95. When trying to deploy this definition, the err msg we get is:

```
Error: -28 13:41:02,675 [ERROR]  Custom model version test failed. Response code: 422. Response body: {"message": "Invalid field data", "errors": {"parameters": {"stabilityCheck": {"passingRate": "value is greater than 1.0"}}}}.
Error: Process completed with exit code 166.
```

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Normalize the passing rate value by dividing it by 100

--------------------------------------------
- [ ] Run all functional tests (>50 minutes)\
**CAUTION**: changing the state of the checkbox will immediately terminate any previous run of the tests.
