### PR TITLE
[RAPTOR-8791] A warning in custom model testing should not be regarded as failure

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -705,17 +705,38 @@ class DrClient:
         response_data = response.json()
 
         if response_data["overallStatus"] != "succeeded":
-            for check, result in response_data["testingStatus"].items():
-                status = result["status"]
-                if status != "succeeded":
-                    raise DataRobotClientError(
-                        f"Custom model version check failed.\nCheck: '{check}'.\nStatus: {status}."
-                        f"\nMessage: {result['message']}"
-                    )
+            self._analyse_custom_model_testing_checks_response(
+                response_data, model_id, model_version_id, model_info
+            )
         logger.debug(
             "Custom model testing pass with success. User provided ID: %s",
             model_info.user_provided_id,
         )
+
+    @staticmethod
+    def _analyse_custom_model_testing_checks_response(
+        response_data, model_id, model_version_id, model_info
+    ):
+        logger.warning(
+            "Custom model version overall testing status, model_path: %s, status: %s",
+            model_info.model_path,
+            response_data["overallStatus"],
+        )
+        for check, result in response_data["testingStatus"].items():
+            status = result["status"]
+            if status == "failed":
+                raise DataRobotClientError(
+                    "Custom model version check failed. "
+                    f"model_id: {model_id}, model_version_id: {model_version_id}, "
+                    f"check: {check}, status: {status}, message: {result['message']}."
+                )
+            if status not in ["success", "skipped"]:
+                logger.warning(
+                    "Custom model version check status, model path: %s, check '%s', status: %s.",
+                    model_info.model_path,
+                    check,
+                    status,
+                )
 
     def _post_custom_model_test_request(self, model_id, model_version_id, model_info):
         payload = {


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Starting a performance check with a small amount of time, finishes the tests with a warning. However, the custom models action execution results in the following error:

```
Error: -28 13:55:13,335 [ERROR]  Custom model version check failed.
Check: 'performanceCheck'.
Status: warning.
Message: The test was interrupted because it exceeded the allotted testing time (1 minute 40 seconds) for the performance check.
Interruption occurred when the 50 MB sample was tested for performance.
```

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Fix the related method to properly handle custom model testing response.
* Unit tests


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
