### PR TITLE
[RAPTOR-8863] Fix a deployment actuals association and related attribute names

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,9 +572,9 @@ settings:
   description: "This is a more detailed description."
   importance: LOW
   association:
-    prediction_id: Animal
+    association_id_column: id
     required_in_pred_request: true
-    actuals_id: Animal
+    actual_values_column: Animal
     actuals_dataset_id: 6d8c889607389fe0f466c72e
   enable_target_drift: true
   enable_feature_drift: true

--- a/src/deployment_controller.py
+++ b/src/deployment_controller.py
@@ -22,7 +22,6 @@ from common.github_env import GitHubEnv
 from deployment_info import DeploymentInfo
 from model_controller import ControllerBase
 from schema_validator import DeploymentSchema
-from schema_validator import ModelSchema
 
 logger = logging.getLogger()
 
@@ -235,26 +234,26 @@ class DeploymentController(ControllerBase):
         self._submit_actuals(deployment_info, deployment)
 
     def _submit_actuals(self, deployment_info, deployment):
-        desired_association_id = deployment_info.get_settings_value(
-            DeploymentSchema.ASSOCIATION_KEY, DeploymentSchema.ASSOCIATION_ACTUALS_ID_KEY
+        desired_association_id_column = deployment_info.get_settings_value(
+            DeploymentSchema.ASSOCIATION_KEY, DeploymentSchema.ASSOCIATION_ASSOCIATION_ID_COLUMN_KEY
         )
         desired_dataset_id = deployment_info.get_settings_value(
             DeploymentSchema.ASSOCIATION_KEY, DeploymentSchema.ASSOCIATION_ACTUALS_DATASET_ID_KEY
         )
-        if desired_association_id and desired_dataset_id:
+        if desired_association_id_column and desired_dataset_id:
             logger.info(
                 "Submitting actuals for a deployment."
-                "Git deployment ID: %s, actuals association ID: %s, actuals dataset ID: %s.",
+                "Git deployment ID: %s, actuals association ID column: %s, actuals dataset ID: %s.",
                 deployment_info.user_provided_id,
-                desired_association_id,
+                desired_association_id_column,
                 desired_dataset_id,
             )
-            model_info = self._model_controller.models_info.get(
-                deployment_info.user_provided_model_id
+            actual_values_column = deployment_info.get_settings_value(
+                DeploymentSchema.ASSOCIATION_KEY,
+                DeploymentSchema.ASSOCIATION_ACTUAL_VALUES_COLUMN_KEY,
             )
-            target_name = model_info.get_settings_value(ModelSchema.TARGET_NAME_KEY)
             self._dr_client.submit_deployment_actuals(
-                target_name, desired_association_id, desired_dataset_id, deployment
+                actual_values_column, desired_association_id_column, desired_dataset_id, deployment
             )
 
     @staticmethod

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -1214,7 +1214,8 @@ class DrClient:
         association_payload = {}
         if cls.should_submit_new_actuals(deployment_info, actual_settings):
             association_col_name = deployment_info.get_settings_value(
-                DeploymentSchema.ASSOCIATION_KEY, DeploymentSchema.ASSOCIATION_PRED_ID_KEY
+                DeploymentSchema.ASSOCIATION_KEY,
+                DeploymentSchema.ASSOCIATION_ASSOCIATION_ID_COLUMN_KEY,
             )
             association_payload["columnNames"] = [association_col_name]
 
@@ -1253,7 +1254,7 @@ class DrClient:
         """
 
         desired_association_pred_id = deployment_info.get_settings_value(
-            DeploymentSchema.ASSOCIATION_KEY, DeploymentSchema.ASSOCIATION_PRED_ID_KEY
+            DeploymentSchema.ASSOCIATION_KEY, DeploymentSchema.ASSOCIATION_ASSOCIATION_ID_COLUMN_KEY
         )
         if desired_association_pred_id is not None:
             actuals_cols = (
@@ -1322,16 +1323,16 @@ class DrClient:
         return response.json()
 
     def submit_deployment_actuals(
-        self, target_name, association_id, actuals_dataset_id, datarobot_deployment
+        self, actual_values_column, association_id_column, actuals_dataset_id, datarobot_deployment
     ):
         """
         Set a deployment actuals information in DataRobot.
 
         Parameters
         ----------
-        target_name : str
+        actual_values_column : str
             The target column name in the Actuals dataset.
-        association_id : str
+        association_id_column : str
             The column name that is used to associate a prediction with the Actuals.
         actuals_dataset_id : str
             A dataset ID from the DataRobot catalogue.
@@ -1346,8 +1347,8 @@ class DrClient:
 
         payload = {
             "datasetId": actuals_dataset_id,
-            "actualValueColumn": target_name,
-            "associationIdColumn": association_id,
+            "actualValueColumn": actual_values_column,
+            "associationIdColumn": association_id_column,
         }
         url = self.DEPLOYMENT_ACTUALS_UPDATE_ROUTE.format(deployment_id=datarobot_deployment["id"])
         response = self._http_requester.post(url, json=payload)

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -625,9 +625,9 @@ class DeploymentSchema(SharedSchema):
     ENABLE_PREDICTIONS_COLLECTION_KEY = "enable_predictions_collection"  # Settings, Optional
 
     ASSOCIATION_KEY = "association"
-    ASSOCIATION_PRED_ID_KEY = "prediction_id"
+    ASSOCIATION_ASSOCIATION_ID_COLUMN_KEY = "association_id_column"
     ASSOCIATION_REQUIRED_IN_PRED_REQUEST_KEY = "required_in_pred_request"
-    ASSOCIATION_ACTUALS_ID_KEY = "actuals_id"
+    ASSOCIATION_ACTUAL_VALUES_COLUMN_KEY = "actual_values_column"
     ASSOCIATION_ACTUALS_DATASET_ID_KEY = "actuals_dataset_id"
 
     ENABLE_CHALLENGER_MODELS_KEY = "enable_challenger_models"
@@ -655,12 +655,13 @@ class DeploymentSchema(SharedSchema):
                     IMPORTANCE_LOW_VALUE,
                 ),
                 Optional(ASSOCIATION_KEY): {
-                    Optional(ASSOCIATION_PRED_ID_KEY): And(str, len),
+                    Optional(ASSOCIATION_ASSOCIATION_ID_COLUMN_KEY): And(str, len),
                     Optional(ASSOCIATION_REQUIRED_IN_PRED_REQUEST_KEY): bool,
                     # NOTE: The ACTUALS dataset is submitted when the deployment is created.
-                    # If the user changes it, later on, in his yaml definition, it'll not be
-                    # uploaded, unless the association ASSOCIATION_PRED_ID_KEY will be changed too.
-                    Optional(ASSOCIATION_ACTUALS_ID_KEY): And(str, len),
+                    # If the user changes it afterwards in his yaml definition, it'll not be
+                    # uploaded, unless the `ASSOCIATION_ASSOCIATION_ID_COLUMN_KEY` will be changed
+                    # too.
+                    Optional(ASSOCIATION_ACTUAL_VALUES_COLUMN_KEY): And(str, len),
                     Optional(ASSOCIATION_ACTUALS_DATASET_ID_KEY): And(str, ObjectId.is_valid),
                 },
                 Optional(ENABLE_TARGET_DRIFT_KEY): bool,  # Update settings

--- a/tests/deployments/deployment.yaml
+++ b/tests/deployments/deployment.yaml
@@ -6,7 +6,7 @@ settings:
   association:
     # In order to enable the accuracy, make sure the 'actuals_dataset_id' exist in DataRobot
     # catalogue. The 'actuals_dataset_id' will be replaced during the functional tests.
-    prediction_id: id
+    association_id_column: id
     required_in_pred_request: false
-    actuals_id: id
+    actual_values_column: Grade 2014
     actuals_dataset_id: 62f0f226bc397a932a9c0c0f

--- a/tests/functional/test_deployment_github_actions.py
+++ b/tests/functional/test_deployment_github_actions.py
@@ -95,13 +95,13 @@ class TestDeploymentGitHubActions:
         self, event_name, dr_client, deployment_metadata, deployment_metadata_yaml_file
     ):
         if event_name == "push":
-            association_id = DeploymentSchema.get_value(
+            association_id_column = DeploymentSchema.get_value(
                 deployment_metadata,
                 DeploymentSchema.SETTINGS_SECTION_KEY,
                 DeploymentSchema.ASSOCIATION_KEY,
-                DeploymentSchema.ASSOCIATION_ACTUALS_ID_KEY,
+                DeploymentSchema.ASSOCIATION_ASSOCIATION_ID_COLUMN_KEY,
             )
-            if association_id:
+            if association_id_column:
                 actuals_filepath = (
                     Path(__file__).parent
                     / ".."


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Fix a deployment's actuals association and rename related attributes to better reflect the corresponding attributes in DataRobot.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Rename association related attributes in the schema.
* Use the `ASSOCIATION_ACTUAL_VALUES_COLUMN_KEY` attribute to associate actuals to a deployment.
* Fix functional tests.


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [x] Run all functional tests (>50 minutes)
