### PR TITLE
[RAPTOR-8895] Increase affected deployments metric upon changes in deployment's settings

### DIFF
--- a/src/deployment_info.py
+++ b/src/deployment_info.py
@@ -50,6 +50,7 @@ class DeploymentInfo:
     def is_challenger_enabled(self):
         """Whether a model challenger is enabled for the given deployment"""
         challenger_enabled = self.get_settings_value(DeploymentSchema.ENABLE_CHALLENGER_MODELS_KEY)
+        # A special case, in which the default is to enable challengers
         return True if challenger_enabled is None else challenger_enabled
 
     def get_value(self, key, *sub_keys):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,9 @@ def github_output():
             os.environ, {"GITHUB_OUTPUT": str(github_output_filepath)}
         ):
             yield github_output_filepath
-        os.remove(github_output_filepath)
+
+        # Just in case the file was not deleted by a certain functional test
+        if github_output_filepath.is_file():
+            github_output_filepath.unlink()
     else:
         yield github_output_env

--- a/tests/unit/test_custom_inference_deployment.py
+++ b/tests/unit/test_custom_inference_deployment.py
@@ -565,11 +565,11 @@ class TestDeploymentChanges:
             create_deployment_method.assert_called_once()
 
     @pytest.fixture
-    def _patch_handle_deployment_changes(self):
-        with patch.object(DeploymentController, "_handle_deployment_changes"):
+    def _patch_handle_deployment_settings(self):
+        with patch.object(DeploymentController, "_handle_deployment_settings"):
             yield
 
-    @pytest.mark.usefixtures("_patch_handle_deployment_changes")
+    @pytest.mark.usefixtures("_patch_handle_deployment_settings")
     def test_model_id_change_in_existing_deployment(
         self, options, _mock_datarobot_model_factory, _mock_deployment_info_factory
     ):
@@ -610,7 +610,7 @@ class TestDeploymentChanges:
 
             create_challenger_in_deployment_method.assert_called_once()
 
-    @pytest.mark.usefixtures("_patch_handle_deployment_changes")
+    @pytest.mark.usefixtures("_patch_handle_deployment_settings")
     def test_new_model_version_in_existing_deployment(
         self, options, _mock_datarobot_model_factory, _mock_deployment_info_factory
     ):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
In case there were changes in deployment's settings only, the metric for affected deployments was not updated. With the given fix, this metric will be updated at such scnario.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Improve the deployment controller to reflect changes in deployment's settings
* Unit and functional tests

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [x] Run all functional tests (>50 minutes)
