### PR TITLE
[RAPTOR-8900] Exclude model's path from model associated files in multi-models YAML definition

### DIFF
--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -258,12 +258,12 @@ class ModelController(ControllerBase):
             excluded_normpaths = [os.path.normpath(p) for p in excluded_paths]
         else:
             excluded_normpaths = []
-        model_root_dir = str(model_info.model_path.absolute())
+        model_normpath = os.path.normpath(model_info.model_path)
         for included_path in included_paths:
             included_normpath = os.path.normpath(included_path)
             if included_normpath in excluded_normpaths:
                 continue
-            if included_normpath == model_root_dir:
+            if included_normpath == model_normpath:
                 continue
             if os.path.isdir(included_normpath):
                 continue

--- a/tests/unit/test_custom_inference_model.py
+++ b/tests/unit/test_custom_inference_model.py
@@ -430,28 +430,40 @@ class TestGlobPatterns:
                 assert readme_file_path.absolute() in model_file_paths
 
     @pytest.mark.parametrize(
-        "included_paths, excluded_paths, expected_num_model_files",
+        "model_path, included_paths, excluded_paths, expected_num_model_files",
         [
-            ({"/m/custom.py", "/m", "/m/score/bbb.md"}, {}, 2),
-            ({"/m/custom.py", "/m/.", "/m/score/bbb.md"}, {}, 2),
-            ({"/m/custom.py", "/m/bbb.py", "/m/score/bbb.md"}, {}, 3),
-            ({"/m/./custom.py", "/m/./bbb.py", "/m/./score/bbb.md"}, {"/m/bbb.py"}, 2),
-            ({"/m/./custom.py", "/m/.//bbb.py", "/m/score/bbb.md"}, {"/m/bbb.py"}, 2),
-            ({"/m/./custom.py", "/m/bbb.py", "/m/score/bbb.py"}, {"/m/bbb.py"}, 2),
-            ({"/m/./custom.py", "/m/bbb.py", "/m/score/bbb.py"}, {"bbb.sh"}, 3),
-            ({"/m/./custom.py", "/m/bbb.py", "/m/score/./bbb.py"}, {"/m/score/bbb.py"}, 2),
-            ({"/m/./custom.py", "/m/bbb.py", "/m/score//bbb.py"}, {"/m/score/bbb.py"}, 2),
-            ({"/m/./custom.py", "/m/.//bbb.py", "/m/score/./bbb.py"}, {"/m/score/bbb.py"}, 2),
-            ({"/m/./custom.py", "/m/score/../bbb.py"}, {"/m/score/bbb.py"}, 2),
-            ({"/m/./custom.py", "/m/score/../bbb.py"}, {"/m/bbb.py"}, 1),
-            ({"/m/./custom.py", "/m//score/bbb.py"}, {"/m//score/bbb.py"}, 1),
-            ({"/m/./custom.py", "/m//score/./bbb.py"}, {"/m/score/bbb.py"}, 1),
+            ("/m", {"/m/custom.py", "/m", "/m/score/bbb.md"}, {}, 2),
+            ("/m", {"/m/custom.py", "/m/.", "/m/score/bbb.md"}, {}, 2),
+            ("/m", {"/m/custom.py", "/m/bbb.py", "/m/score/bbb.md"}, {}, 3),
+            ("/m", {"/m/./custom.py", "/m/./bbb.py", "/m/./score/bbb.md"}, {"/m/bbb.py"}, 2),
+            ("/m", {"/m/./custom.py", "/m/.//bbb.py", "/m/score/bbb.md"}, {"/m/bbb.py"}, 2),
+            ("/m", {"/m/./custom.py", "/m/bbb.py", "/m/score/bbb.py"}, {"/m/bbb.py"}, 2),
+            ("/m", {"/m/./custom.py", "/m/bbb.py", "/m/score/bbb.py"}, {"bbb.sh"}, 3),
+            ("/m", {"/m/./custom.py", "/m/bbb.py", "/m/score/./bbb.py"}, {"/m/score/bbb.py"}, 2),
+            ("/m", {"/m/./custom.py", "/m/bbb.py", "/m/score//bbb.py"}, {"/m/score/bbb.py"}, 2),
+            ("/m", {"/m/./custom.py", "/m/.//bbb.py", "/m/score/./bbb.py"}, {"/m/score/bbb.py"}, 2),
+            ("/m", {"/m/./custom.py", "/m/score/../bbb.py"}, {"/m/score/bbb.py"}, 2),
+            ("/m", {"/m/./custom.py", "/m/score/../bbb.py"}, {"/m/bbb.py"}, 1),
+            ("/m", {"/m/./custom.py", "/m//score/bbb.py"}, {"/m//score/bbb.py"}, 1),
+            ("/m", {"/m/./custom.py", "/m//score/./bbb.py"}, {"/m/score/bbb.py"}, 1),
+            (
+                "/deployments/../m",
+                {
+                    "/deployments/../m/custom.py",
+                    "/deployments/../m",
+                    "/deployments/../m/score/bbb.py",
+                },
+                {"/deployments/../m/score/bbb.py"},
+                1,
+            ),
         ],
     )
-    def test_filtered_model_paths(self, included_paths, excluded_paths, expected_num_model_files):
+    def test_filtered_model_paths(
+        self, model_path, included_paths, excluded_paths, expected_num_model_files
+    ):
         """Test excluded Glob patterns in a given model definition."""
 
-        model_info = ModelInfo("yaml-path", "/m", None)
+        model_info = ModelInfo("yaml-file-path", model_path, None)
         with patch("common.git_tool.Repo.init"), patch("model_controller.DrClient"), patch(
             "model_controller.ModelInfo.user_provided_id", new_callable=PropertyMock("123")
         ):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
If a multi-models YAML definition was placed in a sub folder that is not in the root of the models themselves, the model’s directory path was added as a valid file path to the model’s file list.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Improve the logic to check if a given path equals to the model's directory path.
* Unit tests

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [x] Run all functional tests (>50 minutes)
