### PR TITLE
[RAPTOR-8910] Document governance (deployment's importance) workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,10 @@ prediction_environment_name: "https://eks-test.orm.company.com"
 settings:
   label: "My Awesome Deployment (model-2)"
   description: "This is a more detailed description."
-  importance: LOW
+  importance: LOW  # NOTE: a higher importance value than "LOW" will trigger a review process
+                   # for any operation, such as 'create', 'update', 'delete', etc. So, practically
+                   # the user will need to wait for approval from a reviewer in order to be able
+                   # to apply new changes and merge them to the main branch.
   association:
     association_id_column: id
     required_in_pred_request: true

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -648,6 +648,10 @@ class DeploymentSchema(SharedSchema):
                     And(str, len): And(str, len)
                 },  # fromModelPackage
                 Optional(DESCRIPTION_KEY): And(str, len),  # fromModelPackage
+                # NOTE: a higher importance value than "LOW" will trigger a review process for any
+                # operation, such as 'create', 'update', 'delete', etc. So, practically
+                # the user will need to wait for approval from a reviewer in order to be able
+                # to apply new changes and merge them to the main branch.
                 Optional(IMPORTANCE_KEY): Or(  # fromModelPackage
                     IMPORTANCE_CRITICAL_VALUE,
                     IMPORTANCE_HIGH_VALUE,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
When the user specify an importance higher than “LOW”, an attempt to create a deployment results in a notification to reviewers to approve the new deployment. When such notification is in pending state, waiting for reviewers, the following weird scenarios may happen:

And attempt to delete such deployment will fail, because the deployment was not created yet.

Any following run of the GitHub action, will try to re-create the deployment, which also result in a failure.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add a comment in the `DeploymentSchema` related attribute.
* Add documentation to the README.md


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [x] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
