### PR TITLE
[RAPTOR-8926] Fetch and print deployment's log in case of a deployment's creation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ YAML files enables the custom model action's control over models and deployments
 can reside in any folder within your custom model's repository. The YAML is searched, collected, and tested against 
 a schema to determine if it contains the entities used in these workflows.
 
-## Prerequisites
+## Prerequisite
 The following feature flags must be enabled in DataRobot:
 * ENABLE_MLOPS
 * ENABLE_CUSTOM_INFERENCE_MODEL
 * ENABLE_CUSTOM_MODEL_GITHUB_CI_CD
+
+The following feature flag is optional, for extended information:
+* EXPERIMENTAL_API_ACCESS
 
 (Please contact [DataRobot support](mailto:support@datarobot.com) for more information)
 

--- a/tests/functional/test_deployment_github_actions.py
+++ b/tests/functional/test_deployment_github_actions.py
@@ -11,6 +11,7 @@ DataRobot application. If DataRobot is not accessible, the functional tests are 
 """
 
 import contextlib
+import logging
 import os
 import re
 from pathlib import Path
@@ -63,6 +64,15 @@ def fixture_deployment_metadata(deployment_metadata_yaml_file):
 
     with open(deployment_metadata_yaml_file, encoding="utf-8") as fd:
         return yaml.safe_load(fd)
+
+
+@pytest.fixture(name="skip_association")
+def fixture_skip_association(deployment_metadata_yaml_file, deployment_metadata):
+    """A fixture to remove the association section from a given deployment metadata."""
+
+    deployment_metadata[DeploymentSchema.SETTINGS_SECTION_KEY].pop(DeploymentSchema.ASSOCIATION_KEY)
+    with open(deployment_metadata_yaml_file, "w", encoding="utf-8") as fd:
+        yaml.safe_dump(deployment_metadata, fd)
 
 
 @pytest.fixture(name="cleanup")
@@ -600,3 +610,32 @@ class TestDeploymentGitHubActions:
             expected_predictions_data_collection
             == new_deployment_settings["predictionsDataCollection"]["enabled"]
         )
+
+    @pytest.mark.usefixtures("cleanup", "skip_model_testing", "skip_association")
+    def test_e2e_deployment_create_failure(
+        self, workspace_path, git_repo, model_metadata_yaml_file, main_branch_name, caplog
+    ):
+        """
+        An end-to-end case to test a failure of a background job during a deployment's creation.
+        """
+
+        printout("Run the GitHub action to create an erroneous model and deployment")
+        with self._simulate_model_error(model_metadata_yaml_file):
+            with caplog.at_level(logging.WARNING):
+                run_github_action(
+                    workspace_path, git_repo, main_branch_name, "push", is_deploy=True
+                )
+
+            assert any(record.levelname in ("WARNING", "ERROR") for record in caplog.records)
+        printout("Done")
+
+    @contextlib.contextmanager
+    def _simulate_model_error(self, model_metadata_yaml_file):
+        model_dir_path = Path(model_metadata_yaml_file).parent
+        try:
+            origin_pickle_file_path = next(model_dir_path.rglob("*.pkl"))
+        except StopIteration:
+            assert False, "Missing model's pickle artifact"
+        tmp_pickle_file_path = origin_pickle_file_path.rename(f"{origin_pickle_file_path}.bak")
+        yield
+        tmp_pickle_file_path.rename(origin_pickle_file_path)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
When there’s an error in a deployment creation from a package, is it desired to print the actual logs that might reveal the root cause of the failure. So, in such failure is it required to make a best effort to fetch and print such logs.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add methods to fetch deployment's logs (persistent + runtime)
* Add functional test

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
