### PR TITLE
[RAPTOR-9000] Disable any custom model check that is not explicitly enabled

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -803,15 +803,15 @@ class DrClient:
             "longRunningService": "fail",
             "errorCheck": "fail",
         }
-        if loaded_checks:
-            for check, info in loaded_checks.items():
-                if not info[ModelSchema.CHECK_ENABLED_KEY]:
-                    continue
-
-                dr_check_name = DrApiAttrs.to_dr_test_check(check)
-                configuration[dr_check_name] = (
-                    "fail" if info[ModelSchema.BLOCK_DEPLOYMENT_IF_FAILS_KEY] else "warn"
-                )
+        for local_check_name, dr_check_name in DrApiAttrs.DR_TEST_CHECK_MAP.items():
+            check_config_value = "skip"
+            if loaded_checks:
+                check_info = loaded_checks.get(local_check_name)
+                if check_info[ModelSchema.CHECK_ENABLED_KEY]:
+                    check_config_value = (
+                        "fail" if check_info[ModelSchema.BLOCK_DEPLOYMENT_IF_FAILS_KEY] else "warn"
+                    )
+            configuration[dr_check_name] = check_config_value
         return configuration
 
     @classmethod

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -587,12 +587,31 @@ class TestCustomModelVersionRoutes:
     class TestCustomModelsTestingRoute:
         """Contains unit-tests to test custom model testing routes."""
 
+        @pytest.fixture
+        def default_checks_config(self):
+            """
+            A fixture that returns the default configuration for custom model testing checks,
+            when checks are disabled or do not exist in the model's YAML definition.
+            """
+
+            return {
+                "errorCheck": "fail",
+                "longRunningService": "fail",
+                "nullValueImputation": "skip",
+                "performanceCheck": "skip",
+                "predictionVerificationCheck": "skip",
+                "sideEffects": "skip",
+                "stabilityCheck": "skip",
+            }
+
         @pytest.mark.parametrize("loaded_checks", [None, {}], ids=["none", "empty_dict"])
-        def test_minimal_custom_model_testing_configuration(self, loaded_checks):
+        def test_minimal_custom_model_testing_configuration(
+            self, loaded_checks, default_checks_config
+        ):
             """A case to test minimal configuration for a custom model testing."""
 
             configuration = DrClient._build_tests_configuration(loaded_checks)
-            assert configuration == {"longRunningService": "fail", "errorCheck": "fail"}
+            assert configuration == default_checks_config
 
         @pytest.mark.parametrize("loaded_checks", [None, {}], ids=["none", "empty_dict"])
         def test_minimal_custom_model_testing_parameters(self, loaded_checks):
@@ -612,7 +631,7 @@ class TestCustomModelVersionRoutes:
                 assert check in configuration
 
         def test_full_custom_model_testing_configuration_with_all_disabled_checks(
-            self, mock_full_custom_model_checks
+            self, mock_full_custom_model_checks, default_checks_config
         ):
             """
             A case to test a full custom model testing configuration, when all the checks are
@@ -623,7 +642,7 @@ class TestCustomModelVersionRoutes:
             for _, info in mock_full_custom_model_checks.items():
                 info[ModelSchema.CHECK_ENABLED_KEY] = False
             configuration = DrClient._build_tests_configuration(mock_full_custom_model_checks)
-            assert configuration == {"longRunningService": "fail", "errorCheck": "fail"}
+            assert configuration == default_checks_config
 
         def test_full_custom_model_testing_parameters(self, mock_full_custom_model_checks):
             """A case to test a full number of parameters in custom model testing."""


### PR DESCRIPTION
## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Currently, if a given check if disabled in the definition file, the default is taken from whatever is configured in DataRobot. It is desired that the single source of truth will be the local model definition (YAML).

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Include "skip" configuration value for any check that is disabled or does not exist.
* Unit tests

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [x] Run all functional tests (>50 minutes)
