### PR TITLE
[RAPTOR-9001] Fix the issue that a dependency image was not used in a custom model testing

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -761,13 +761,7 @@ class DrClient:
                 logger.debug("Check status, check '%s', status: %s.", check, status)
 
     def _post_custom_model_test_request(self, model_id, model_version_id, model_info):
-        payload = {
-            "customModelId": model_id,
-            "customModelVersionId": model_version_id,
-            "environmentId": model_info.get_value(
-                ModelSchema.VERSION_KEY, ModelSchema.MODEL_ENV_ID_KEY
-            ),
-        }
+        payload = {"customModelId": model_id, "customModelVersionId": model_version_id}
 
         loaded_checks = model_info.get_value(ModelSchema.TEST_KEY, ModelSchema.CHECKS_KEY)
         configuration = self._build_tests_configuration(loaded_checks)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Using the GitHub action, a model was defined to have dependencies and testing enabled. An attempt to push a commit of that model, resulted in an error that indicates that the dependency image was not used during the custom model testing.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Do not deliver the environment ID when launching a custom model testing.


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
