### PR TITLE
[RAPTOR-8896] Fetch an installed sklearn environment drop-in from DR for the functional tests

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -59,6 +59,7 @@ class DrClient:
     DEPLOYMENT_MODEL_VALIDATION_ROUTE = DEPLOYMENT_MODEL_ROUTE + "validation/"
     DEPLOYMENT_MODEL_CHALLENGER_ROUTE = DEPLOYMENT_ROUTE + "challengers/"
     DEPLOYMENT_ACTUALS_UPDATE_ROUTE = DEPLOYMENT_ROUTE + "actuals/fromDataset/"
+    ENVIRONMENT_DROP_IN_ROUTE = "executionEnvironments/"
 
     MODEL_TARGET_TYPE_MAP = {
         ModelSchema.TARGET_TYPE_BINARY_KEY: "Binary",
@@ -1740,3 +1741,22 @@ class DrClient:
                 )
             return response.json()
         return None
+
+    def fetch_environment_drop_in(self, search_for=None):
+        """
+        Retrieve environments drop-in from DataRobot.
+
+        Parameters
+        ----------
+        search_for : str or None
+            Optional. A string to filter out environments in DataRobot. The search is done
+            in the name and description of every environment drop-in, and it is case insensitive.
+
+        Returns
+        -------
+        list:
+            A list of environment drop-in environments.
+        """
+
+        payload = {"searchFor": search_for} if search_for else None
+        return self._paginated_fetch(self.ENVIRONMENT_DROP_IN_ROUTE, json=payload)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Apparently, in local development, the environment might be reinstalled very often. Consequently, the environment ID, that is set in the deployment YAML file becomes outdated and the failure is weird (404, Not found when trying to created custom model version).

It’ll be best to identify the local development and when preparing the model’s YAML file, make sure to fetch the installed environment and set the proper environment ID in the YAML file.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add a fixture to fetch an installed sklearn environment drop-in from DataRobot.
* Use this fixture in the functional tests.


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
