### PR TITLE
[RAPTOR-8897] Add a metric to count the number of models & deployments whose settings were updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ repository in GitHub, take the following steps:
             with:
               fetch-depth: 0
 
-              - name: DataRobot Custom Models Step
-                id: datarobot-custom-models-step
-                uses: datarobot-oss/custom-models-action@v1.1.8
-                with:
-                  api-token: ${{ secrets.DATAROBOT_API_TOKEN }}
-                  webserver: https://app.datarobot.com/
-                  branch: master
-                  allow-model-deletion: true
-                  allow-deployment-deletion: true
+          - name: DataRobot Custom Models Step
+            id: datarobot-custom-models-step
+            uses: datarobot-oss/custom-models-action@v1.1.8
+            with:
+              api-token: ${{ secrets.DATAROBOT_API_TOKEN }}
+              webserver: https://app.datarobot.com/
+              branch: master
+              allow-model-deletion: true
+              allow-deployment-deletion: true
     ```
     
     Configure the following fields:
@@ -223,16 +223,18 @@ The action supports the following optional input arguments:
 The GitHub action supports the following output arguments, which can later be used by follow-up
 steps in the same GitHub job (refer to the workflow example below):
 
-|    Argument   |                   Description                  |
-|---------------|------------------------------------------------|
-| `total-affected-models`        | The number of models affected by this action. |
-| `total-created-models`         | The number of new models created by this action. |
-| `total-deleted-models`         | The number of models deleted by this action. |
-| `total-created-model-versions` | The number of new model versions created by this action. |
-| `total-affected-deployments`   | The number of deployments affected by this action. |
-| `total-created-deployments`    | The number of new deployments created by this action. |
-| `total-deleted-deployments`    | The number of deployments deleted by this action. |
-| `message`                      | The output message from the GitHub action. |
+| Argument                              | Description                                              |
+|---------------------------------------|----------------------------------------------------------|
+| `models--total-affected`              | The number of models affected by this action.            |
+| `models--total-created`               | The number of new models created by this action.         |
+| `models--total-deleted`               | The number of models deleted by this action.             |
+| `models--total-updated-settings`      | The number of models whose settings were updated.        |
+| `models--total-created-versions`      | The number of new model versions created by this action. |
+| `deployments--total-affected`         | The number of deployments affected by this action.       |
+| `deployments--total-created`          | The number of new deployments created by this action.    |
+| `deployments--total-deleted`          | The number of deployments deleted by this action.        |
+| `deployments--total-updated-settings` | The number of deployments whose settings were updated.   |
+| `message`                             | The output message from the GitHub action.               |
 
 ### Model Definition
 
@@ -344,12 +346,12 @@ GitHub workflow definition:
         # This will be taken care of by the push event.
         if: ${{ github.event.pull_request.merged != true }}
 
-          runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-          steps:
-            - uses: actions/checkout@v3
-              with:
-                fetch-depth: 0
+        steps:
+          - uses: actions/checkout@v3
+            with:
+              fetch-depth: 0
 
           - name: DataRobot Custom Models Step
             id: datarobot-custom-models-step
@@ -663,16 +665,18 @@ jobs:
           allow-model-deletion: true
           allow-deployment-deletion: true
 
-      - name: DataRobot Custom Models Action Results
+      - name: DataRobot Custom Models Action Metrics
         run: |
-          echo "Total affected models: ${{ steps.datarobot-custom-models-step.outputs.total-affected-models }}"
-          echo "Total created models: ${{ steps.datarobot-custom-models-step.outputs.total-created-models }}"
-          echo "Total deleted models: ${{ steps.datarobot-custom-models-step.outputs.total-deleted-models }}"
-          echo "Total created model versions: ${{ steps.datarobot-custom-models-step.outputs.total-created-model-versions }}"
+          echo "Total affected models: ${{ steps.datarobot-custom-models-step.outputs.models--total-affected }}"
+          echo "Total created models: ${{ steps.datarobot-custom-models-step.outputs.models--total-created }}"
+          echo "Total deleted models: ${{ steps.datarobot-custom-models-step.outputs.models--total-deleted }}"
+          echo "Total models whose settings were updated: ${{ steps.datarobot-custom-models-step.outputs.models--total-updated-settings }}"
+          echo "Total created model versions: ${{ steps.datarobot-custom-models-step.outputs.models--total-created-versions }}"
 
-          echo "Total affected deployments: ${{ steps.datarobot-custom-models-step.outputs.total-affected-deployments }}"
-          echo "Total created deployments: ${{ steps.datarobot-custom-models-step.outputs.total-created-deployments }}"
-          echo "Total deleted deployments: ${{ steps.datarobot-custom-models-step.outputs.total-deleted-deployments }}"
+          echo "Total affected deployments: ${{ steps.datarobot-custom-models-step.outputs.deployments--total-affected }}"
+          echo "Total created deployments: ${{ steps.datarobot-custom-models-step.outputs.deployments--total-created }}"
+          echo "Total deleted deployments: ${{ steps.datarobot-custom-models-step.outputs.deployments--total-deleted }}"
+          echo "Total deployments whose settings were updated: ${{ steps.datarobot-custom-models-step.outputs.deployments--total-updated-settings }}"
 
           echo "Message: ${{ steps.datarobot-custom-models-step.outputs.message }}"
 ```

--- a/src/common/constants.py
+++ b/src/common/constants.py
@@ -5,5 +5,14 @@
 
 """Contains common constants."""
 
+from enum import Enum
+
 # Only once custom model type is supported
 CUSTOM_MODEL_TYPE = "inference"
+
+
+class Label(Enum):
+    """An enum of entity labels."""
+
+    MODELS = "models"
+    DEPLOYMENTS = "deployments"

--- a/src/custom_models_action.py
+++ b/src/custom_models_action.py
@@ -125,6 +125,6 @@ class CustomModelsAction:
         return True
 
     def _save_statistics(self):
-        self.model_controller.save_statistics()
+        self.model_controller.save_metrics()
         if self.deployment_controller:
-            self.deployment_controller.save_statistics()
+            self.deployment_controller.save_metrics()

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,102 @@
+#  Copyright (c) 2023. DataRobot, Inc. and its affiliates.
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+
+"""
+This module holds model and deployment's metrics, which are collected during the GitHub action's
+execution.
+"""
+
+import dataclasses
+from dataclasses import dataclass
+
+from common.constants import Label
+from common.github_env import GitHubEnv
+
+
+@dataclass
+class Metric:
+    """A data class that holds a single metric related attributes."""
+
+    label: str
+    value: int
+
+
+@dataclass
+class Metrics:
+    """Contains metric attributes that will be exposed by the GitHub actions."""
+
+    # Both models & deployment
+    total_affected: Metric = Metric("total-affected", 0)
+    total_created: Metric = Metric("total-created", 0)
+    total_deleted: Metric = Metric("total-deleted", 0)
+    total_updated_settings: Metric = Metric("total-updated-settings", 0)
+
+    # Model only
+    total_created_versions: Metric = Metric("total-created-versions", 0)
+
+    def __init__(self, entity_label):
+        self._entity_label = entity_label
+        for metric in self._get_metrics(entity_label):
+            metric_attr = getattr(self, metric.name)
+            metric_attr.value = 0
+
+    @classmethod
+    def metric_labels(cls, entity_label):
+        """
+        Returns the all the supported metric names for models or deployments.
+
+        Parameters
+        ----------
+        entity_label : common.constants.Label
+            The entity label for which to return the metric names.
+
+        Returns
+        -------
+        set:
+            A set of metric labels
+        """
+
+        return {
+            cls.metric_label(entity_label, metric.default.label)
+            for metric in cls._get_metrics(entity_label)
+        }
+
+    @classmethod
+    def metric_label(cls, entity_label, raw_metric_label):
+        """
+        Returns a formatted metric label.
+
+        Parameters
+        ----------
+        entity_label : common.constants.Label
+            An entity label (e.g. Label.MODELS, Label.DEPLOYMENTS).
+        raw_metric_label : str
+            The base metric name.
+
+        Returns
+        -------
+        str:
+            A formatted metric label.
+        """
+
+        return f"{entity_label.value}--{raw_metric_label}"
+
+    @classmethod
+    def _get_metrics(cls, entity_label):
+        metrics = set()
+        for metric in dataclasses.fields(cls):
+            if entity_label == Label.DEPLOYMENTS and metric.name == "total_created_versions":
+                continue
+            metrics.add(metric)
+        return metrics
+
+    def save(self):
+        """Save the metrics to the GitHub environment."""
+
+        for metric in self._get_metrics(self._entity_label):
+            metric_attr = getattr(self, metric.name)
+            GitHubEnv.set_output_param(
+                self.metric_label(self._entity_label, metric.default.label), metric_attr.value
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def github_output():
         ):
             yield github_output_filepath
 
-        # Just in case the file was not deleted by a certain functional test
+        # Just in case the file was not deleted by a certain test
         if github_output_filepath.is_file():
             github_output_filepath.unlink()
     else:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
In addition to the existing metrics a new metric is now provided, which counts the number of models and deployments whose settings were updated.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Change the term `statistics` to `metrics` all over the place.
* Change the metric names format.
* Refactor the metrics design and put its handling in its own separate module.
* Add new metrics: `models--total-updated-settings` & `deployments--total-updated-settings`.
* Unit & Functional tests.

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [x] Run all functional tests (>50 minutes)
