### PR TITLE
[RAPTOR-9059] Fetch and handle only entities that were created by the GitHub action

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -137,7 +137,7 @@ class DrClient:
 
     def fetch_custom_models(self):
         """
-        Retrieve custom models from DataRobot.
+        Retrieve custom models from DataRobot, which were created by the GitHub action.
 
         Returns
         -------
@@ -145,8 +145,9 @@ class DrClient:
             A list of DataRobot custom models.
         """
 
-        logger.debug("Fetching custom models...")
-        return self._paginated_fetch(self.CUSTOM_MODELS_ROUTE)
+        logger.debug("Fetching custom models.")
+        models = self._paginated_fetch(self.CUSTOM_MODELS_ROUTE)
+        return [m for m in models if m.get("userProvidedId")]
 
     def fetch_custom_model_by_git_id(self, user_provided_id):
         """
@@ -979,7 +980,7 @@ class DrClient:
 
     def fetch_deployments(self):
         """
-        Retrieve deployments from DataRobot.
+        Retrieve deployments from DataRobot, which were created by the GitHub action.
 
         Returns
         -------
@@ -988,7 +989,10 @@ class DrClient:
         """
 
         logger.debug("Fetching deployments.")
-        return self._paginated_fetch(self.DEPLOYMENTS_ROUTE)
+        deployments = self._paginated_fetch(
+            self.DEPLOYMENTS_ROUTE, json={"execution_environment_type": "datarobot"}
+        )
+        return [d for d in deployments if d.get("userProvidedId")]
 
     def fetch_deployment_by_git_id(self, user_provided_id):
         """


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
It is important to guarantee that the GitHub action always handles entities that were created by the GitHub action. As a starting point it is essential, when fetching models and deployments, to filter out those that were not created by the GitHub action. This can be achieved by looking for the `userProvidedId` attribute in the fetched entities. 

One example is a cleanup fixture that iterates over models and deployments in order to delete them. It is important that it’ll iterate only over those were created by the GitHub action.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Improve the fetch methods in dr_client to return models and deployments that were created by GitHub action.
* Unit tests

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
