### PR TITLE
[RAPTOR-9063] Add support for namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,28 @@ This action requires the following input arguments:
 
 The action supports the following optional input arguments:
 
-|    Argument   |                   Description                  |
-|---------------|------------------------------------------------|
+| Argument                      | Description                                                                                                               |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `--namespace`                 | Determines the namespace under which models and deployments will be created, updated and deleted.                         |
 | `--allow-deployment-deletion` | Determines whether to detect local deleted deployment definitions and delete them in DataRobot. <br> **Default**: `false` |
-| `--allow-model-deletion`      | Determines whether to detect local deleted model definitions and delete them in DataRobot <br> **Default**: `false` |
-| `--models-only`               | Determines whether to manage custom inference models only or also deployments <br> **Default**: `false` |
-| `--skip-cert-verification`    | Determines whether a request to an HTTPS URL is made without a certificate verification. <br> **Default**: `false` |
+| `--allow-model-deletion`      | Determines whether to detect local deleted model definitions and delete them in DataRobot <br> **Default**: `false`       |
+| `--models-only`               | Determines whether to manage custom inference models only or also deployments <br> **Default**: `false`                   |
+| `--skip-cert-verification`    | Determines whether a request to an HTTPS URL is made without a certificate verification. <br> **Default**: `false`        |
+
+### A Namespace (Optional)
+
+A namespace is a unique string that can be provided as input argument to the action. The purpose is
+to guarantee that the custom model action only handles models and deployments that exist in the
+configured namespace. Any other models and deployments that are not in the configured namespace
+will remain untouched.
+
+By default, a namespace is not configured, which means all entities created by a custom model action
+will be processed during execution.
+
+The namespace enable users to work with the same model and deployment definition files on different
+branches, as long as they configure a different namespaces to the custom models action in the GitHub
+workflow. This means that each user will have its own models and definitions, which will reside
+in different namespaces.
 
 ### The GitHub Action's Output Metrics
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,11 @@ inputs:
   branch:  # id of input
     description: 'The branch for which pull request and push events will trigger the action.'
     required: true
+  namespace:
+    description: |
+      Determines the namespace under which models and deployments will be created, updated and
+      deleted.
+    required: false
   allow-model-deletion:
     description:  |
       Whether to detected local deleted model definitions and consequently delete them
@@ -68,32 +73,19 @@ runs:
       shell: bash
     - id: custom-models-action
       run: |
-        if ${{ inputs.allow-model-deletion }} == true; then
-          allow_model_deletion_arg="--allow-model-deletion"
-        else
-          allow_model_deletion_arg=""
-        fi
-        if ${{ inputs.allow-deployment-deletion }} == true; then
-          allow_deployment_deletion_arg="--allow-deployment-deletion"
-        else
-          allow_deployment_deletion_arg=""
-        fi
-        if ${{ inputs.models_only }} == true; then
-          models_only_arg="--models-only"
-        else
-          models_only_arg=""
-        fi
-        if ${{ inputs.skip-cert-verification }} == true; then
-          verify_cert_arg="--skip-cert-verification"
-        else
-          verify_cert_arg=""
-        fi 
+        ${{ inputs.namespace != '' }} && namespace_arg='--namespace ${{ inputs.namespace }}'
+        ${{ inputs.allow-model-deletion == 'true' }} && allow_model_deletion_arg='--allow-model-deletion'
+        ${{ inputs.allow-deployment-deletion == 'true' }} && allow_deployment_deletion_arg='--allow-deployment-deletion'
+        ${{ inputs.models_only == 'true' }} && models_only_arg='--models-only'
+        ${{ inputs.skip-cert-verification == 'true' }} && verify_cert_arg='--skip-cert-verification'
+
         python ${GITHUB_ACTION_PATH}/src/main.py \
           --api-token ${{ inputs.api-token }} \
           --webserver ${{ inputs.webserver }} \
           --branch ${{ inputs.branch }} \
+          ${namespace_arg} \
           ${allow_model_deletion_arg} \
           ${allow_deployment_deletion_arg} \
           ${models_only_arg} \
-          ${verify_cert_arg} \
+          ${verify_cert_arg}
       shell: bash

--- a/src/common/exceptions.py
+++ b/src/common/exceptions.py
@@ -114,3 +114,15 @@ class AssociatedModelVersionNotFound(GenericException):
 
 class EmptyKey(GenericException):
     """Raised when an invalid empty key is provided to get a value from a metadata."""
+
+
+class NamespaceAlreadySet(GenericException):
+    """Raised when trying to set a namespace more than once."""
+
+
+class InvalidEmptyArgument(GenericException):
+    """Raise when a None or empty input argument is provided to a method."""
+
+
+class IllegalDeletion(GenericException):
+    """Raised when trying to delete a model or deployment, when it is not eligible for deletion."""

--- a/src/common/namepsace.py
+++ b/src/common/namepsace.py
@@ -1,0 +1,91 @@
+#  Copyright (c) 2023. DataRobot, Inc. and its affiliates.
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+
+"""A module that contains methods to handle a namespace."""
+
+from common.exceptions import InvalidEmptyArgument
+from common.exceptions import NamespaceAlreadySet
+
+
+class Namespace:
+    """Provides access and handling methods to namespace."""
+
+    _namespace = None
+
+    @classmethod
+    def namespace(cls):
+        """Return the namespace."""
+
+        return cls._namespace
+
+    @classmethod
+    def set_namespace(cls, namespace, force_override=False):
+        """
+        Set a namespace. The namespace can be set only once.
+
+        Parameters
+        ----------
+        namespace : str
+            A non-empty string.
+        force_override : bool
+            Whether to override an already configured namespace.
+        """
+
+        if not namespace:
+            raise InvalidEmptyArgument("Namespace must be a valid string.")
+
+        if namespace == cls._namespace:
+            # Happens during the functional tests
+            return
+
+        if cls._namespace and not force_override:
+            raise NamespaceAlreadySet(
+                f"A namespace has already been set. Existing: {cls._namespace}, new: {namespace}."
+            )
+
+        cls._namespace = namespace
+
+    @classmethod
+    def unset_namespace(cls):
+        """Unset the namespace."""
+
+        cls._namespace = None
+
+    @classmethod
+    def is_in_namespace(cls, user_provided_id):
+        """
+        Whether a given user provided ID belongs to the namespace if exists.
+
+        Parameters
+        ----------
+        user_provided_id : str
+            A user provided ID.
+        """
+
+        if cls._namespace:
+            return user_provided_id.startswith(f"{cls._namespace}/")
+        return True
+
+    @classmethod
+    def namespaced(cls, user_provided_id):
+        """
+        Returns the input argument's user provided ID with a prefixed namespace (if exists).
+        If the input user_provided_id already starts with the namespace, it will be returned
+        untouched.
+
+        Parameters
+        ----------
+        user_provided_id : str
+            A user provided ID.
+
+        Returns
+        -------
+        str:
+            The user provided ID with a prefixed namespace if exists.
+
+        """
+        if not cls._namespace or cls.is_in_namespace(user_provided_id):
+            return user_provided_id
+        return f"{cls._namespace}/{user_provided_id}"

--- a/src/deployment_info.py
+++ b/src/deployment_info.py
@@ -8,11 +8,12 @@ A module that contains information about a deployment that was scanned and loade
 source tree.
 """
 
+from model_info import InfoBase
 from schema_validator import DeploymentSchema
 from schema_validator import SharedSchema
 
 
-class DeploymentInfo:
+class DeploymentInfo(InfoBase):
     """Holds information about a deployment in the local source tree"""
 
     def __init__(self, yaml_path, deployment_metadata):

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ import sys
 
 from common.exceptions import GenericException
 from common.github_env import GitHubEnv
+from common.namepsace import Namespace
 from custom_models_action import CustomModelsAction
 
 logger = logging.getLogger()
@@ -44,6 +45,9 @@ def argparse_options(args=None):
     )
     parser.add_argument(
         "--branch", required=True, help="The branch against which the program will function."
+    )
+    parser.add_argument(
+        "--namespace", help="It is used to group and isolate models and deployments."
     )
     parser.add_argument(
         "--allow-model-deletion",
@@ -101,7 +105,8 @@ def main(args=None):
 
     setup_log_configuration()
     options = argparse_options(args)
-
+    if options.namespace:
+        Namespace.set_namespace(options.namespace)
     try:
         CustomModelsAction(options).run()
         GitHubEnv.set_output_param(

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -9,6 +9,8 @@ source tree.
 """
 
 import logging
+from abc import ABC
+from abc import abstractmethod
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
@@ -21,7 +23,68 @@ from schema_validator import ModelSchema
 logger = logging.getLogger()
 
 
-class ModelInfo:
+class InfoBase(ABC):
+    """An abstract base class for models and deployments information classes."""
+
+    @property
+    @abstractmethod
+    def yaml_filepath(self):
+        """The yaml file path from which the given metadata definition is read from."""
+
+    @property
+    @abstractmethod
+    def metadata(self):
+        """The metadata dictionary."""
+
+    @property
+    @abstractmethod
+    def user_provided_id(self):
+        """
+        A unique ID that is provided by the user to identify a given definition and read from
+        the metadata.
+        """
+
+    @abstractmethod
+    def get_value(self, key, *sub_keys):
+        """
+        Get a value from the model's metadata given a key and sub-keys.
+
+        Parameters
+        ----------
+        key : str
+            A key name from the Schema.
+        sub_keys :
+            An optional dynamic sub-keys from the Schema.
+
+        Returns
+        -------
+        Any or None,
+            The value associated with the provided key (and sub-keys) or None if not exists.
+        """
+
+    @abstractmethod
+    def get_settings_value(self, key, *sub_keys):
+        """
+        Get a value from the metadata settings section, given a key and sub-keys under
+        the settings section.
+
+        Parameters
+        ----------
+        key : str
+            A key name from the Schema, which is supposed to be under the
+            SharedSchema.SETTINGS_SECTION_KEY section.
+        sub_keys :
+            An optional dynamic sub-keys from the ModelSchema, which are under the
+            SharedSchema.SETTINGS_SECTION_KEY section.
+
+        Returns
+        -------
+        Any or None,
+            The value associated with the provided key (and sub-keys) or None if not exists.
+        """
+
+
+class ModelInfo(InfoBase):
     """Holds information about a model from the local source tree."""
 
     _model_file_paths: Dict[Path, ModelFilePath]

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -22,6 +22,7 @@ from common.exceptions import EmptyKey
 from common.exceptions import InvalidModelSchema
 from common.exceptions import InvalidSchema
 from common.exceptions import UnexpectedType
+from common.namepsace import Namespace
 
 logger = logging.getLogger()
 
@@ -270,7 +271,7 @@ class ModelSchema(SharedSchema):
 
     MODEL_SCHEMA = Schema(
         {
-            SharedSchema.MODEL_ID_KEY: And(str, len),
+            SharedSchema.MODEL_ID_KEY: And(str, len, Use(Namespace.namespaced)),
             TARGET_TYPE_KEY: Or(
                 TARGET_TYPE_BINARY_KEY,
                 TARGET_TYPE_REGRESSION_KEY,
@@ -638,8 +639,8 @@ class DeploymentSchema(SharedSchema):
 
     DEPLOYMENT_SCHEMA = Schema(
         {
-            DEPLOYMENT_ID_KEY: And(str, len),
-            SharedSchema.MODEL_ID_KEY: And(str, len),
+            DEPLOYMENT_ID_KEY: And(str, len, Use(Namespace.namespaced)),
+            SharedSchema.MODEL_ID_KEY: And(str, len, Use(Namespace.namespaced)),
             # fromCustomModel + fromModelPackage
             Optional(PREDICTION_ENVIRONMENT_NAME_KEY): And(str, len),
             Optional(SharedSchema.SETTINGS_SECTION_KEY): {

--- a/tests/deployments/deployment.yaml
+++ b/tests/deployments/deployment.yaml
@@ -1,5 +1,5 @@
-user_provided_deployment_id: my-awesome-deployment-id-04941f36-2f44-11ed-99fd-9b2fd871ddc8
-user_provided_model_id: my-awesome-model-id-ef2de33e-2f43-11ed-8a31-1357d73ba08a
+user_provided_deployment_id: deployment-id-1
+user_provided_model_id: model-id-1
 
 settings:
   description: This is a test deployment.

--- a/tests/functional/test_model_github_actions.py
+++ b/tests/functional/test_model_github_actions.py
@@ -688,5 +688,5 @@ class TestMultiModelsOneDefinitionGitHubAction:
         assert len(multi_models_yaml_filepath) == 1
         multi_models_yaml_filepath = multi_models_yaml_filepath[0]
         with open(multi_models_yaml_filepath, encoding="utf-8") as fd:
-            multi_models_metadata = yaml.safe_load(fd)
+            multi_models_metadata = ModelSchema.validate_and_transform_multi(yaml.safe_load(fd))
         return multi_models_metadata

--- a/tests/models/py3_sklearn/model.yaml
+++ b/tests/models/py3_sklearn/model.yaml
@@ -1,4 +1,4 @@
-user_provided_model_id: my-awesome-model-id-ef2de33e-2f43-11ed-8a31-1357d73ba08a
+user_provided_model_id: model-id-1
 
 target_type: Regression
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
The idea is to enable users to provide a namespace, which is a plain string, to the GitHub action (optional input argument), which will be used to isolate all the loaded models and deployments by that namespace. With that the GitHub action is guaranteed to always work with models and deployments that are only in that namespace.

The GitHub action will automatically add the namespace string as a prefix to the user provided ID attribute of every loaded models and deployments. Users will not be required to write the namespace in their YAML definitions.

There are few benefits for such capability:
* Enable to globally isolate models and deployments that were created by different stakeholders.
* A safe guard for individuals as well as groups to avoid collisions.
* Enable to define an isolated namespace for the functional tests, thus keeping all the products isolated.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add a new `namespace` module.
* Add support to filter out models and deployments which are not in the configured namespace.
* Add the configured namespace prefix for the user provided IDs of the loaded model and deployment definitions.
* Add new `--namespace` input argument to the action main script.
* Add support for a namespace in the action's definition file (`action.yaml`)
* Update the `README.md`
* Some small refactoring.
* Configure a namespace to the functional tests. 
* Unit & Functional tests.

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [x] Run all functional tests (>50 minutes)
