### PR TITLE
[RAPTOR-9079] Use GitHub repository ID as the namespace unless it is set by the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,18 +221,17 @@ The action supports the following optional input arguments:
 
 ### A Namespace (Optional)
 
-A namespace is a unique string that can be provided as input argument to the action. The purpose is
-to guarantee that the custom model action only handles models and deployments that exist in the
-configured namespace. Any other models and deployments that are not in the configured namespace
-will remain untouched.
+A namespace is a unique string that can be provided as an input argument to the action. The
+purpose is to guarantee that the custom model action handles models and deployments that only exist
+in the configured namespace. Any other models and deployments that are not in the configured
+namespace will remain untouched.
 
-By default, a namespace is not configured, which means all entities created by a custom model action
-will be processed during execution.
+If not provided, the GitHub repository ID will be used as the namespace. It means that the custom
+models action will process models and deployments that were created from this repository only.
 
-The namespace enable users to work with the same model and deployment definition files on different
-branches, as long as they configure a different namespaces to the custom models action in the GitHub
-workflow. This means that each user will have its own models and definitions, which will reside
-in different namespaces.
+If, for instance, users would like to work with the same model and deployment definitions from
+different branches and still make sure that each will have its own isolated models and deployments,
+they can simply configure a different namespace to the custom models action in the GitHub workflow.
 
 ### The GitHub Action's Output Metrics
 

--- a/src/common/exceptions.py
+++ b/src/common/exceptions.py
@@ -120,8 +120,8 @@ class NamespaceAlreadySet(GenericException):
     """Raised when trying to set a namespace more than once."""
 
 
-class InvalidEmptyArgument(GenericException):
-    """Raise when a None or empty input argument is provided to a method."""
+class NamespaceNotInitialized(GenericException):
+    """Raise when trying to use the namespace methods without first initializing it."""
 
 
 class IllegalDeletion(GenericException):

--- a/src/common/github_env.py
+++ b/src/common/github_env.py
@@ -52,7 +52,7 @@ class GitHubEnv:
 
     @staticmethod
     def base_ref():
-        """The name of the base ref or target branch of the pull request in a workflow run.o"""
+        """The name of the base ref or target branch of the pull request in a workflow run."""
 
         return os.environ.get("GITHUB_BASE_REF")
 
@@ -61,6 +61,12 @@ class GitHubEnv:
         """The default location of the repository when using the checkout action."""
 
         return Path(os.environ.get("GITHUB_WORKSPACE"))
+
+    @staticmethod
+    def repository_id():
+        """The ID of the repository."""
+
+        return os.environ.get("GITHUB_REPOSITORY_ID")
 
     @staticmethod
     def github_output():

--- a/src/main.py
+++ b/src/main.py
@@ -105,8 +105,7 @@ def main(args=None):
 
     setup_log_configuration()
     options = argparse_options(args)
-    if options.namespace:
-        Namespace.set_namespace(options.namespace)
+    Namespace.init(options.namespace)
     try:
         CustomModelsAction(options).run()
         GitHubEnv.set_output_param(

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -359,7 +359,7 @@ class ModelController(ControllerBase):
         latest_version = self.datarobot_models[model_info.user_provided_id].latest_version
         git_model_version = latest_version.get("gitModelVersion")
         if not git_model_version:
-            # Either the model has never provisioned of the user created a version with a non
+            # Either the model has never provisioned or the user created a version with a non
             # GitHub action client.
             return False
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -47,10 +47,11 @@ def setup_functional_tests_namespace_fixture():
     """
 
     try:
-        Namespace.set_namespace(FUNCTIONAL_TESTS_NAMESPACE)
+        with github_env_set("GITHUB_REPOSITORY_ID", "1234567"):
+            Namespace.init(FUNCTIONAL_TESTS_NAMESPACE)
         yield
     finally:
-        Namespace.unset_namespace()
+        Namespace.uninit()
 
 
 def create_dr_client():
@@ -576,9 +577,11 @@ def run_github_action(
 
     main_branch_head_sha = main_branch_head_sha or git_repo.head.commit.hexsha
     ref_name = main_branch_name if event_name == "push" else "merge-branch"
-    with github_env_set("GITHUB_WORKSPACE", str(workspace_path)), github_env_set(
-        "GITHUB_SHA", git_repo.commit(main_branch_head_sha).hexsha
-    ), github_env_set("GITHUB_EVENT_NAME", event_name), github_env_set(
+    with github_env_set("GITHUB_REPOSITORY_ID", "1234567"), github_env_set(
+        "GITHUB_WORKSPACE", str(workspace_path)
+    ), github_env_set("GITHUB_SHA", git_repo.commit(main_branch_head_sha).hexsha), github_env_set(
+        "GITHUB_EVENT_NAME", event_name
+    ), github_env_set(
         "GITHUB_SHA", git_repo.commit(main_branch_head_sha).hexsha
     ), github_env_set(
         "GITHUB_BASE_REF", main_branch_name


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
A namespace is a unique string that can be provided as an input argument to the action. The
purpose is to guarantee that the custom model action handles models and deployments that only exist
in the configured namespace. Any other models and deployments that are not in the configured
namespace will remain untouched.

**If not provided, the GitHub repository ID will be used as the namespace.** It means that the custom
models action will process models and deployments that were created from this repository only.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add the GitHub repository ID as the default namespace if not provided by the user.
* Update README.md
* Unit & Functional tests


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
