### PR TITLE
[RAPTOR-9189] Update the README with regards to version.replicas to reflect the default in DR

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ version:
   include_glob_pattern:
     - ./
   memory: 100Mi
-  replicas: 3
+  replicas: 2
 
 test:
   memory: 100Mi


### PR DESCRIPTION
## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
The default configuration (EngConfig) for the custom inference models replicas limit in DR SaaS is 2. In the custom models action README doc, the example shows 3 for the corresponding configuration value. 

It is required to change it to 2 in order to avoid users getting potential errors when just bulk copying parts of the yaml.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Update README.md

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [x] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
