### PR TITLE
[RAPTOR-9212] Fix a failure to set segment analysis attributes after it was enabled

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -1335,12 +1335,14 @@ class DrClient:
             DeploymentSchema.SEGMENT_ANALYSIS_KEY,
             DeploymentSchema.ENABLE_SEGMENT_ANALYSIS_KEY,
         )
-        if desired_enabled is not None:
-            actual_enabled = (
-                actual_settings["segmentAnalysis"]["enabled"] if actual_settings else None
-            )
-            if desired_enabled != actual_enabled:
-                segmented_analysis_payload = {"enabled": desired_enabled}
+        desired_enabled = bool(desired_enabled)
+        actual_enabled = (
+            actual_settings.get("segmentAnalysis", {}).get("enabled", False)
+            if actual_settings
+            else False
+        )
+        if desired_enabled != actual_enabled:
+            segmented_analysis_payload = {"enabled": desired_enabled}
 
         desired_attributes = deployment_info.get_settings_value(
             DeploymentSchema.SEGMENT_ANALYSIS_KEY,
@@ -1348,10 +1350,16 @@ class DrClient:
         )
         if desired_attributes is not None:
             actual_attributes = (
-                actual_settings["segmentAnalysis"]["attributes"] if actual_settings else None
+                actual_settings.get("segmentAnalysis", {}).get("attributes")
+                if actual_settings
+                else None
             )
             if desired_attributes != actual_attributes:
-                segmented_analysis_payload["attributes"] = desired_attributes
+                # The `enabled` attribute is mandatory, so make sure it is set.
+                segmented_analysis_payload = {
+                    "enabled": desired_enabled,
+                    "attributes": desired_attributes,
+                }
 
         return segmented_analysis_payload
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
There was an issue in which segment analysis attributes could not be set if the segment analysis was already enabled in a previous run.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Fix the related functionality to build the segment analysis payload
* Unit tests


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
