### PR TITLE
[RAPTOR-9228] Add support to set training/holdout data at custom model version level

### DIFF
--- a/src/common/git_model_version.py
+++ b/src/common/git_model_version.py
@@ -1,0 +1,76 @@
+#  Copyright (c) 2023. DataRobot, Inc. and its affiliates.
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+
+"""A module that holds local git details."""
+
+import logging
+
+from common.git_tool import GitTool
+from common.github_env import GitHubEnv
+
+logger = logging.getLogger()
+
+
+class GitModelVersion:
+    """A class that holds local git information."""
+
+    def __init__(self, repo, branch):
+        self._ref_name = GitHubEnv.ref_name()
+        if GitHubEnv.is_pull_request():
+            if repo.num_remotes() == 0:
+                # Only to support the functional tests, which do not have a remote repository.
+                main_branch = branch
+            else:
+                # This is the expected path when working against a remote GitHub repository.
+                main_branch = f"{repo.remote_name()}/{branch}"
+            self._main_branch_commit_sha = repo.merge_base_commit_sha(
+                main_branch, GitHubEnv.github_sha()
+            )
+            self._pull_request_commit_sha = repo.feature_branch_top_commit_sha_of_a_merge_commit(
+                GitHubEnv.github_sha()
+            )
+            self._commit_url = GitTool.GITHUB_COMMIT_URL_PATTERN.format(
+                user_and_project=GitHubEnv.github_repository(), sha=self._pull_request_commit_sha
+            )
+        else:
+            self._main_branch_commit_sha = GitHubEnv.github_sha()
+            self._pull_request_commit_sha = None
+            self._commit_url = GitTool.GITHUB_COMMIT_URL_PATTERN.format(
+                user_and_project=GitHubEnv.github_repository(), sha=self._main_branch_commit_sha
+            )
+        logger.info(
+            "GitHub version info. Ref name: %s, commit URL: %s, main branch commit sha: %s, "
+            "pull request commit sha: %s",
+            self._ref_name,
+            self._commit_url,
+            self._main_branch_commit_sha,
+            self._pull_request_commit_sha,
+        )
+
+    @property
+    def ref_name(self):
+        """The branch or tag name that triggered the GitHub workflow run."""
+
+        return self._ref_name
+
+    @property
+    def commit_url(self):
+        """The commit URL in GitHub."""
+
+        return self._commit_url
+
+    @property
+    def main_branch_commit_sha(self):
+        """The commit SHA that triggered the GitHub workflow."""
+
+        return self._main_branch_commit_sha
+
+    @property
+    def pull_request_commit_sha(self):
+        """
+        For pull-requests it is the top commit in a merge branch, which was created from a feature
+        branch as part of a pull request. For push events it is None."""
+
+        return self._pull_request_commit_sha

--- a/tests/functional/test_model_training_holdout_data.py
+++ b/tests/functional/test_model_training_holdout_data.py
@@ -1,0 +1,448 @@
+#  Copyright (c) 2023. DataRobot, Inc. and its affiliates.
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+
+# pylint: disable=too-many-arguments
+
+"""
+Functional tests for the custom inference model training/holdout data, which are handled by the
+GitHub action. The functional tests are executed against a running DataRobot application. If
+DataRobot is not accessible, the functional tests are skipped.
+"""
+
+import contextlib
+from pathlib import Path
+
+import pytest
+
+from common.exceptions import DataRobotClientError
+from schema_validator import ModelSchema
+from tests.functional.conftest import cleanup_models
+from tests.functional.conftest import printout
+from tests.functional.conftest import run_github_action
+from tests.functional.conftest import temporarily_replace_schema_value
+from tests.functional.conftest import (
+    temporarily_upload_training_dataset_for_structured_model,
+)
+from tests.functional.conftest import upload_and_update_dataset
+from tests.functional.conftest import webserver_accessible
+
+
+@pytest.mark.skipif(not webserver_accessible(), reason="DataRobot webserver is not accessible.")
+@pytest.mark.usefixtures("cleanup", "skip_model_testing", "github_output")
+class TestModelTrainingHoldoutData:
+    """A test class that contains training and holdout data related test cases."""
+
+    def test_e2e_set_training_and_holdout_datasets_for_structured_model(
+        self,
+        dr_client,
+        workspace_path,
+        git_repo,
+        model_metadata,
+        model_metadata_yaml_file,
+        main_branch_name,
+    ):
+        """
+        And end-to-end case to test a training dataset assignment for structured model, by the
+        custom inference model GitHub action. The training dataset contains a holdout column.
+        """
+
+        # 1. Create a model just as a preliminary requirement (use GitHub action)
+        printout(
+            "Create a custom model as a preliminary requirement. "
+            "Run custom model GitHub action (push event) ..."
+        )
+        run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
+
+        user_provided_id = ModelSchema.get_value(model_metadata, ModelSchema.MODEL_ID_KEY)
+        with temporarily_upload_training_dataset_for_structured_model(
+            dr_client, model_metadata_yaml_file, is_model_level=True, event_name="push"
+        ) as (training_dataset_id_1, partition_column_1):
+            try:
+                self._commit_run_and_validata_training_holdout_data_for_model(
+                    git_repo,
+                    dr_client,
+                    model_metadata_yaml_file,
+                    workspace_path,
+                    main_branch_name,
+                    user_provided_id,
+                    training_dataset_id_1,
+                    partition_column=partition_column_1,
+                )
+            except Exception:
+                cleanup_models(dr_client, workspace_path)
+                raise
+
+            with temporarily_upload_training_dataset_for_structured_model(
+                dr_client, model_metadata_yaml_file, is_model_level=True, event_name="push"
+            ) as (training_dataset_id_2, partition_column_2):
+                try:
+                    self._commit_run_and_validata_training_holdout_data_for_model(
+                        git_repo,
+                        dr_client,
+                        model_metadata_yaml_file,
+                        workspace_path,
+                        main_branch_name,
+                        user_provided_id,
+                        training_dataset_id_2,
+                        partition_column=partition_column_2,
+                    )
+                    assert training_dataset_id_1 != training_dataset_id_2
+                    assert partition_column_1 == partition_column_2
+                finally:
+                    cleanup_models(dr_client, workspace_path)
+        printout("Done")
+
+    @staticmethod
+    def _commit_run_and_validata_training_holdout_data_for_model(
+        git_repo,
+        dr_client,
+        model_metadata_yaml_file,
+        workspace_path,
+        main_branch_name,
+        user_provided_id,
+        training_dataset_id,
+        holdout_dataset_id=None,
+        partition_column=None,
+    ):
+        git_repo.git.add(model_metadata_yaml_file)
+        git_repo.git.commit("-m", "Update training / holdout dataset(s)")
+
+        printout("Run custom inference models GitHub action ...")
+        run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
+
+        # Validation
+        custom_model = dr_client.fetch_custom_model_by_git_id(user_provided_id)
+        if partition_column is not None:
+            # Implicitly structured models
+            assert custom_model["trainingDatasetId"] == training_dataset_id
+            assert custom_model["trainingDataPartitionColumn"] == partition_column
+        else:
+            assert holdout_dataset_id is not None
+            assert (
+                custom_model["externalMlopsStatsConfig"]["trainingDatasetId"] == training_dataset_id
+            )
+            assert (
+                custom_model["externalMlopsStatsConfig"]["holdoutDatasetId"] == holdout_dataset_id
+            )
+        versions = dr_client.fetch_custom_model_versions(custom_model["id"])
+        assert len(versions) == 1
+
+    def test_e2e_set_training_and_holdout_datasets_for_structured_model_version(
+        self,
+        dr_client,
+        workspace_path,
+        git_repo,
+        model_metadata,
+        model_metadata_yaml_file,
+        main_branch_name,
+    ):
+        """
+        Test a training dataset assignment for structured model version, by the custom inference
+        model GitHub action. The training dataset contains a holdout column.
+        """
+
+        # 1. Create a model just as a preliminary requirement (use GitHub action)
+        printout(
+            "Create a custom model as a preliminary requirement. "
+            "Run custom model GitHub action (push event) ..."
+        )
+        run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
+
+        with temporarily_upload_training_dataset_for_structured_model(
+            dr_client, model_metadata_yaml_file, is_model_level=False, event_name="push"
+        ) as (training_dataset_id_1, partition_column_1):
+            try:
+                self._commit_training_holdout_data_changes_for_model_version(
+                    git_repo, model_metadata_yaml_file, workspace_path, main_branch_name
+                )
+            except Exception:
+                cleanup_models(dr_client, workspace_path)
+                raise
+
+            with temporarily_upload_training_dataset_for_structured_model(
+                dr_client, model_metadata_yaml_file, is_model_level=False, event_name="push"
+            ) as (training_dataset_id_2, partition_column_2):
+                try:
+                    self._commit_training_holdout_data_changes_for_model_version(
+                        git_repo, model_metadata_yaml_file, workspace_path, main_branch_name
+                    )
+                    self._validate_training_holdout_data_in_model_versions(
+                        dr_client,
+                        model_metadata,
+                        training_dataset_id_1,
+                        training_dataset_id_2,
+                        partition_column_1=partition_column_1,
+                        partition_column_2=partition_column_2,
+                    )
+                finally:
+                    cleanup_models(dr_client, workspace_path)
+        printout("Done")
+
+    @staticmethod
+    def _commit_training_holdout_data_changes_for_model_version(
+        git_repo, model_metadata_yaml_file, workspace_path, main_branch_name
+    ):
+        git_repo.git.add(model_metadata_yaml_file)
+        git_repo.git.commit("-m", "Update training / holdout dataset(s)")
+
+        printout("Run custom inference models GitHub action ...")
+        run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
+
+    @staticmethod
+    def _validate_training_holdout_data_in_model_versions(
+        dr_client,
+        model_metadata,
+        training_dataset_id_1,
+        training_dataset_id_2,
+        holdout_dataset_id_1=None,
+        partition_column_1=None,
+        holdout_dataset_id_2=None,
+        partition_column_2=None,
+    ):
+        assert training_dataset_id_1 != training_dataset_id_2
+
+        custom_model = dr_client.fetch_custom_model_by_git_id(
+            ModelSchema.get_value(model_metadata, ModelSchema.MODEL_ID_KEY)
+        )
+        versions = dr_client.fetch_custom_model_versions(custom_model["id"])
+        assert len(versions) == 3
+        assert custom_model["latestVersion"]["id"] == versions[0]["id"]
+        assert versions[0]["trainingData"]["datasetId"] == training_dataset_id_2
+        assert versions[1]["trainingData"]["datasetId"] == training_dataset_id_1
+        training_data = versions[2].get("trainingData")
+        assert training_data is None or training_data.get("datasetId") is None
+        holdout_data = versions[2].get("holdoutData")
+        if holdout_dataset_id_1:
+            assert holdout_dataset_id_2 is not None
+            assert holdout_dataset_id_1 != holdout_dataset_id_2
+            assert versions[0]["holdoutData"]["datasetId"] == holdout_dataset_id_2
+            assert versions[1]["holdoutData"]["datasetId"] == holdout_dataset_id_1
+            assert holdout_data is None or holdout_data.get("datasetId") is None
+        else:
+            assert partition_column_1 is not None
+            assert partition_column_1 == partition_column_2
+            assert versions[0]["holdoutData"]["partitionColumn"] == partition_column_2
+            assert versions[1]["holdoutData"]["partitionColumn"] == partition_column_1
+            assert holdout_data is None or holdout_data.get("partitionColumn") is None
+
+    def test_e2e_set_training_dataset_with_wrong_model_target_name(
+        self,
+        dr_client,
+        workspace_path,
+        git_repo,
+        model_metadata,
+        model_metadata_yaml_file,
+        main_branch_name,
+    ):
+        """
+        And end-to-end case to test a training dataset assignment for structured model, whose
+        definition initially contains wrong target name.
+        """
+
+        with temporarily_upload_training_dataset_for_structured_model(
+            dr_client, model_metadata_yaml_file, is_model_level=True, event_name="push"
+        ) as (training_dataset_id, partition_column):
+            try:
+                git_repo.git.add(model_metadata_yaml_file)
+                git_repo.git.commit("-m", "Update training / holdout dataset(s)")
+
+                printout(
+                    "Create a custom model with wrong target name. "
+                    "Run custom model GitHub action (push event) ..."
+                )
+
+                with temporarily_replace_schema_value(
+                    model_metadata_yaml_file,
+                    ModelSchema.SETTINGS_SECTION_KEY,
+                    ModelSchema.TARGET_NAME_KEY,
+                    new_value="wrong-target-name",
+                ):
+                    git_repo.git.add(model_metadata_yaml_file)
+                    git_repo.git.commit("-m", "Set wrong target name")
+
+                    with pytest.raises(DataRobotClientError) as ex:
+                        run_github_action(
+                            workspace_path, git_repo, main_branch_name, "push", is_deploy=False
+                        )
+                    assert ex.value.code == 422, ex.value
+                    assert (
+                        "Custom model's target is not found in the provided dataset"
+                        in ex.value.args[0]
+                    )
+
+                git_repo.git.add(model_metadata_yaml_file)
+                git_repo.git.commit("-m", "Set valid target name")
+
+                printout("Run custom inference models GitHub action with proper target ...")
+                run_github_action(
+                    workspace_path, git_repo, main_branch_name, "push", is_deploy=False
+                )
+
+                # Validate
+                user_provided_id = ModelSchema.get_value(model_metadata, ModelSchema.MODEL_ID_KEY)
+                custom_model = dr_client.fetch_custom_model_by_git_id(user_provided_id)
+                assert custom_model["trainingDatasetId"] == training_dataset_id
+                assert custom_model["trainingDataPartitionColumn"] == partition_column
+            finally:
+                cleanup_models(dr_client, workspace_path)
+
+        printout("Done")
+
+    def test_e2e_set_training_and_holdout_datasets_for_unstructured_model(
+        self,
+        dr_client,
+        workspace_path,
+        git_repo,
+        model_metadata,
+        model_metadata_yaml_file,
+        main_branch_name,
+    ):
+        """
+        An end-to-end case to test training and holdout dataset assignment for unstructured
+        model by the custom inference model GitHub action.
+        """
+
+        with temporarily_replace_schema_value(
+            model_metadata_yaml_file,
+            ModelSchema.TARGET_TYPE_KEY,
+            new_value=ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER_KEY,
+        ):
+            # 1. Create a model just as a preliminary requirement (use GitHub action)
+            printout(
+                "Create a custom model as a preliminary requirement. "
+                "Run custom model GitHub action (push event) ..."
+            )
+            run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
+
+            user_provided_id = ModelSchema.get_value(model_metadata, ModelSchema.MODEL_ID_KEY)
+
+            with self._set_and_upload_training_and_holdout_data(
+                1, dr_client, model_metadata_yaml_file, is_model_level=True
+            ) as (training_dataset_id_1, holdout_dataset_id_1):
+                try:
+                    self._commit_run_and_validata_training_holdout_data_for_model(
+                        git_repo,
+                        dr_client,
+                        model_metadata_yaml_file,
+                        workspace_path,
+                        main_branch_name,
+                        user_provided_id,
+                        training_dataset_id_1,
+                        holdout_dataset_id=holdout_dataset_id_1,
+                    )
+                except Exception:
+                    cleanup_models(dr_client, workspace_path)
+                    raise
+
+                with self._set_and_upload_training_and_holdout_data(
+                    2, dr_client, model_metadata_yaml_file, is_model_level=True
+                ) as (training_dataset_id_2, holdout_dataset_id_2):
+                    try:
+                        self._commit_run_and_validata_training_holdout_data_for_model(
+                            git_repo,
+                            dr_client,
+                            model_metadata_yaml_file,
+                            workspace_path,
+                            main_branch_name,
+                            user_provided_id,
+                            training_dataset_id_2,
+                            holdout_dataset_id=holdout_dataset_id_2,
+                        )
+                        assert training_dataset_id_1 != training_dataset_id_2
+                        assert holdout_dataset_id_1 != holdout_dataset_id_2
+                    finally:
+                        cleanup_models(dr_client, workspace_path)
+
+        printout("Done")
+
+    @contextlib.contextmanager
+    def _set_and_upload_training_and_holdout_data(
+        self, index, dr_client, model_metadata_yaml_file, is_model_level
+    ):
+        printout(
+            f"({index}) Upload training and holdout datasets for unstructured model. "
+            f"is_model_level: {is_model_level}"
+        )
+        datasets_root = Path(__file__).parent / ".." / "datasets"
+        training_dataset_filepath = (
+            datasets_root / "juniors_3_year_stats_regression_unstructured_training.csv"
+        )
+        holdout_dataset_filepath = (
+            datasets_root / "juniors_3_year_stats_regression_unstructured_holdout.csv"
+        )
+        section_key = (
+            ModelSchema.SETTINGS_SECTION_KEY if is_model_level else ModelSchema.VERSION_KEY
+        )
+        with upload_and_update_dataset(
+            dr_client,
+            training_dataset_filepath,
+            model_metadata_yaml_file,
+            section_key,
+            ModelSchema.TRAINING_DATASET_ID_KEY,
+        ) as training_dataset_id, upload_and_update_dataset(
+            dr_client,
+            holdout_dataset_filepath,
+            model_metadata_yaml_file,
+            section_key,
+            ModelSchema.HOLDOUT_DATASET_ID_KEY,
+        ) as holdout_dataset_id:
+            yield training_dataset_id, holdout_dataset_id
+
+    def test_e2e_set_training_and_holdout_datasets_for_unstructured_model_version(
+        self,
+        dr_client,
+        workspace_path,
+        git_repo,
+        model_metadata,
+        model_metadata_yaml_file,
+        main_branch_name,
+    ):
+        """
+        An end-to-end case to test training and holdout dataset assignment for unstructured
+        model by the custom inference model GitHub action.
+        """
+
+        with temporarily_replace_schema_value(
+            model_metadata_yaml_file,
+            ModelSchema.TARGET_TYPE_KEY,
+            new_value=ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER_KEY,
+        ):
+            # 1. Create a model just as a preliminary requirement (use GitHub action)
+            printout(
+                "Create a custom model as a preliminary requirement. "
+                "Run custom model GitHub action (push event) ..."
+            )
+            run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
+
+            with self._set_and_upload_training_and_holdout_data(
+                1, dr_client, model_metadata_yaml_file, is_model_level=False
+            ) as (training_dataset_id_1, holdout_dataset_id_1):
+                try:
+                    self._commit_training_holdout_data_changes_for_model_version(
+                        git_repo, model_metadata_yaml_file, workspace_path, main_branch_name
+                    )
+                except Exception:
+                    cleanup_models(dr_client, workspace_path)
+                    raise
+
+                with self._set_and_upload_training_and_holdout_data(
+                    2, dr_client, model_metadata_yaml_file, is_model_level=False
+                ) as (training_dataset_id_2, holdout_dataset_id_2):
+                    try:
+                        self._commit_training_holdout_data_changes_for_model_version(
+                            git_repo, model_metadata_yaml_file, workspace_path, main_branch_name
+                        )
+                        self._validate_training_holdout_data_in_model_versions(
+                            dr_client,
+                            model_metadata,
+                            training_dataset_id_1,
+                            training_dataset_id_2,
+                            holdout_dataset_id_1=holdout_dataset_id_1,
+                            holdout_dataset_id_2=holdout_dataset_id_2,
+                        )
+                    finally:
+                        cleanup_models(dr_client, workspace_path)
+
+        printout("Done")

--- a/tests/functional/test_multi_models_definition.py
+++ b/tests/functional/test_multi_models_definition.py
@@ -1,0 +1,79 @@
+#  Copyright (c) 2023. DataRobot, Inc. and its affiliates.
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+
+# pylint: disable=too-many-arguments
+
+"""
+Functional tests for a single definition YAML file which contains multiple model's definition.
+The functional tests are executed against a running DataRobot application. If DataRobot is not
+accessible, the functional tests are skipped.
+"""
+
+import glob
+
+import pytest
+import yaml
+
+from schema_validator import ModelSchema
+from tests.functional.conftest import printout
+from tests.functional.conftest import run_github_action
+from tests.functional.conftest import webserver_accessible
+
+
+# pylint: disable=too-few-public-methods
+@pytest.mark.skipif(not webserver_accessible(), reason="DataRobot webserver is not accessible.")
+@pytest.mark.usefixtures("github_output", "cleanup")
+class TestMultiModelsOneDefinitionGitHubAction:
+    """A class to test multi-models definition in a single metadata YAML file"""
+
+    @pytest.mark.parametrize(
+        "is_abs_model_path, model_path_prefix", [(True, "/"), (True, "$ROOT/"), (False, None)]
+    )
+    def test_e2e_pull_request_event_with_multi_model_definition(
+        self,
+        dr_client,
+        workspace_path,
+        git_repo,
+        main_branch_name,
+        build_repo_for_testing_factory,
+        is_abs_model_path,
+        model_path_prefix,
+    ):
+        """
+        An end-to-end case to test model deletion by the custom inference model GitHub action
+        from a pull-request. The test first creates a PR with a simple change in order to create
+        the model in DataRobot. Afterwards, it creates another PR to delete the model definition,
+        which should delete the model in DataRobot.
+        """
+
+        build_repo_for_testing_factory(
+            dedicated_model_definition=False,
+            is_absolute_model_path=is_abs_model_path,
+            model_path_prefix=model_path_prefix,
+        )
+        printout("Run custom model GitHub action (push event) ...")
+        run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
+
+        printout("Validate after merging ...")
+
+        multi_models_metadata = self._load_multi_models_metadata(workspace_path)
+        models = dr_client.fetch_custom_models()
+
+        expected_user_provided_ids = {
+            model_entry[ModelSchema.MODEL_ENTRY_META_KEY][ModelSchema.MODEL_ID_KEY]
+            for model_entry in multi_models_metadata[ModelSchema.MULTI_MODELS_KEY]
+        }
+        actual_user_provided_ids = {model.get("userProvidedId") for model in models}
+        assert expected_user_provided_ids <= actual_user_provided_ids
+        printout("Done")
+
+    @staticmethod
+    def _load_multi_models_metadata(workspace_path):
+        multi_models_yaml_filepath = glob.glob(str(workspace_path / "**/models.yaml"))
+        assert len(multi_models_yaml_filepath) == 1
+        multi_models_yaml_filepath = multi_models_yaml_filepath[0]
+        with open(multi_models_yaml_filepath, encoding="utf-8") as fd:
+            multi_models_metadata = ModelSchema.validate_and_transform_multi(yaml.safe_load(fd))
+        return multi_models_metadata

--- a/tests/models/py3_sklearn/model.yaml
+++ b/tests/models/py3_sklearn/model.yaml
@@ -1,15 +1,16 @@
-user_provided_model_id: model-id-1
+user_provided_model_id: awesome-model-id
 
 target_type: Regression
 
 settings:
-  name: My Awsome GitHub Model 1 [GitHub CI/CD]
+  name: My Awsome GitHub Model [GitHub CI/CD]
   target_name: Grade 2014
 
 version:
   # Make sure this is the environment ID in your system.
   # It is the '[DataRobot] Python 3 Scikit-Learn Drop-In' environment
   model_environment_id: 5e8c889607389fe0f466c72d
+  exclude_glob_pattern: [model.yaml]
 
 test:
   # Make sure it exists in DataRobot catalogue. Will be replaced during the functional tests.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -578,3 +578,11 @@ def validate_namespaced_user_provided_id(info_bases, namespace):
         assert Namespace.is_in_namespace(info.user_provided_id)
         if namespace:
             assert info.user_provided_id.startswith(f"{namespace}/")
+
+
+@pytest.fixture(autouse=True)
+def mock_git_model_version():
+    """A fixture to mock the GitModelVersion class in the model controller."""
+
+    with patch("model_controller.GitModelVersion"):
+        yield

--- a/tests/unit/test_custom_inference_model.py
+++ b/tests/unit/test_custom_inference_model.py
@@ -513,6 +513,7 @@ class TestGlobPatterns:
             webserver="www.dummy.com",
             api_token="abc",
             skip_cert_verification=True,
+            branch="master",
         )
         with patch.object(
             ModelController, "models_info", new_callable=PropertyMock

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -230,7 +230,8 @@ class TestModelSchemaValidator:
                 self._validate_schema(is_single, model_schema)
 
     @pytest.mark.parametrize("is_single", [True, False], ids=["single", "multi"])
-    def test_invalid_mutual_exclusive_keys_partitioning_and_holdout(self, is_single):
+    @pytest.mark.parametrize("section", [ModelSchema.SETTINGS_SECTION_KEY, ModelSchema.VERSION_KEY])
+    def test_invalid_mutual_exclusive_keys_partitioning_and_holdout(self, is_single, section):
         """
         A case to test an invalid mutual exclusive keys related to partitioning and holdout
         attributes.
@@ -243,18 +244,55 @@ class TestModelSchemaValidator:
             if is_single
             else model_metadata[ModelSchema.MULTI_MODELS_KEY][0][ModelSchema.MODEL_ENTRY_META_KEY]
         )
-        edit_metadata[ModelSchema.SETTINGS_SECTION_KEY][ModelSchema.HOLDOUT_DATASET_ID_KEY] = str(
-            ObjectId()
-        )
-        edit_metadata[ModelSchema.SETTINGS_SECTION_KEY][
-            ModelSchema.PARTITIONING_COLUMN_KEY
-        ] = "holdout"
+        edit_metadata[section][ModelSchema.PARTITIONING_COLUMN_KEY] = "partitioning"
+        edit_metadata[section][ModelSchema.HOLDOUT_DATASET_ID_KEY] = str(ObjectId())
 
         with pytest.raises(InvalidModelSchema):
             if is_single:
                 ModelSchema.validate_and_transform_single(model_metadata)
             else:
                 ModelSchema.validate_and_transform_multi(model_metadata)
+
+    @pytest.mark.parametrize("is_single", [True, False], ids=["single", "multi"])
+    @pytest.mark.parametrize("is_unstructured", [True, False], ids=["unstructured", "structured"])
+    @pytest.mark.parametrize("with_holdout", [True, False], ids=["with-holdout", "without-holdout"])
+    def test_invalid_mutual_exclusive_training_and_holdout_keys_between_settings_and_version(
+        self, is_single, is_unstructured, with_holdout
+    ):
+        """
+        A case to test an invalid mutual exclusive keys between model settings section and version
+        section, related to training and holdout dataset attributes.
+        """
+
+        model_metadata = create_partial_model_schema(is_single, num_models=1, with_target_type=True)
+
+        edit_metadata = (
+            model_metadata
+            if is_single
+            else model_metadata[ModelSchema.MULTI_MODELS_KEY][0][ModelSchema.MODEL_ENTRY_META_KEY]
+        )
+        sections_in_test = [ModelSchema.SETTINGS_SECTION_KEY, ModelSchema.VERSION_KEY]
+        for index in range(2):
+            section_one = sections_in_test[index]
+            section_two = sections_in_test[index ^ 1]
+            if is_unstructured:
+                edit_metadata[section_one][ModelSchema.TRAINING_DATASET_ID_KEY] = str(ObjectId())
+                edit_metadata[section_two][ModelSchema.TRAINING_DATASET_ID_KEY] = str(ObjectId())
+                if with_holdout:
+                    edit_metadata[section_one][ModelSchema.HOLDOUT_DATASET_ID_KEY] = str(ObjectId())
+                    edit_metadata[section_two][ModelSchema.HOLDOUT_DATASET_ID_KEY] = str(ObjectId())
+            else:
+                edit_metadata[section_one][ModelSchema.TRAINING_DATASET_ID_KEY] = str(ObjectId())
+                edit_metadata[section_two][ModelSchema.TRAINING_DATASET_ID_KEY] = str(ObjectId())
+                if with_holdout:
+                    edit_metadata[section_one][ModelSchema.PARTITIONING_COLUMN_KEY] = "partitioning"
+                    edit_metadata[section_two][ModelSchema.PARTITIONING_COLUMN_KEY] = "partitioning"
+
+            with pytest.raises(InvalidModelSchema):
+                if is_single:
+                    ModelSchema.validate_and_transform_single(model_metadata)
+                else:
+                    ModelSchema.validate_and_transform_multi(model_metadata)
 
     @pytest.mark.parametrize("is_single", [True, False], ids=["single", "multi"])
     @pytest.mark.parametrize(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
* This PR support for training/holdout data at model's version levels. 
* When defined at version level - the model will be created with the `is_training_data_for_versions_permanently_enabled` set to true.
* The related training/holdout attributes at model vs. modelv's version are mutually exclusive.
* The action will also provide hints for what needs to be done in case of an error - e.g. "Training dataset is expected at the version level. Consider moving the definition to the version section of the model."


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [x] Run all functional tests (>50 minutes)
