### PR TITLE
[RPTOR-9297] Fix 'NoneType' object is not subscriptable in custom model checks

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -822,7 +822,7 @@ class DrClient:
             check_config_value = "skip"
             if loaded_checks:
                 check_info = loaded_checks.get(local_check_name)
-                if check_info[ModelSchema.CHECK_ENABLED_KEY]:
+                if check_info and check_info[ModelSchema.CHECK_ENABLED_KEY]:
                     check_config_value = (
                         "fail" if check_info[ModelSchema.BLOCK_DEPLOYMENT_IF_FAILS_KEY] else "warn"
                     )

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -691,6 +691,24 @@ class TestCustomModelVersionRoutes:
             parameters = DrClient._build_tests_parameters(loaded_checks)
             assert not parameters
 
+        def test_partial_custom_model_testing_configuration(self):
+            """A case to test a full configuration of custom model testing."""
+
+            partial_configuration = {
+                ModelSchema.NULL_VALUE_IMPUTATION_KEY: {
+                    ModelSchema.CHECK_ENABLED_KEY: True,
+                    ModelSchema.BLOCK_DEPLOYMENT_IF_FAILS_KEY: True,
+                }
+            }
+
+            configuration = DrClient._build_tests_configuration(partial_configuration)
+            assert (
+                DrApiAttrs.to_dr_test_check(ModelSchema.NULL_VALUE_IMPUTATION_KEY) in configuration
+            )
+            # The following checks are silently added
+            for check in ["longRunningService", "errorCheck"]:
+                assert check in configuration
+
         def test_full_custom_model_testing_configuration(self, mock_full_custom_model_checks):
             """A case to test a full configuration of custom model testing."""
 


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
This PR fixes a bug of a partial configuration of the custom model checks.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add a condition to validate that a check exists in the configuration file.
* Unit test

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
