### PR TITLE
[RAPTOR-8926] Fetch and print deployment's log in case of a deployment's creation failure (#296)

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -50,6 +50,7 @@ class DrClient:
     )
     CUSTOM_MODELS_TEST_ROUTE = "customModelTests/"
     CUSTOM_MODEL_DEPLOYMENTS_ROUTE = "customModelDeployments/"
+    CUSTOM_MODEL_DEPLOYMENT_LOG_ROUTE = CUSTOM_MODEL_DEPLOYMENTS_ROUTE + "{deployment_id}/logs/"
     CUSTOM_MODEL_TRAINING_DATA = CUSTOM_MODEL_ROUTE + "trainingData/"
     DATASETS_ROUTE = "datasets/"
     DATASET_UPLOAD_ROUTE = DATASETS_ROUTE + "fromFile/"
@@ -1193,18 +1194,66 @@ class DrClient:
         response = self._http_requester.post(self.DEPLOYMENTS_CREATE_ROUTE, json=payload)
         if response.status_code != 202:
             raise DataRobotClientError(
-                "Failed creating a deployment from model package."
+                "Failed creating a deployment from a model package."
                 f"User provided deployment id: {deployment_info.user_provided_id}, "
                 f"Model package id: {model_package['id']}, "
                 f"Response status: {response.status_code}, "
                 f"Response body: {response.text}",
                 code=response.status_code,
             )
-        location = self._wait_for_async_resolution(
-            response.headers["Location"], max_wait=self.DEPLOYMENT_CREATE_MAX_WAIT_SEC
+        deployment_id = response.json()["id"]
+        try:
+            location = self._wait_for_async_resolution(
+                response.headers["Location"], max_wait=self.DEPLOYMENT_CREATE_MAX_WAIT_SEC
+            )
+        except HttpRequesterException as ex:
+            self._report_persistent_deployment_logs_if_any(deployment_id)
+            raise DataRobotClientError(
+                "A certain background job was failing during a deployment's creation. "
+                f"DataRobot deployment id: {deployment_id}, "
+                f"User provided deployment id: {deployment_info.user_provided_id}, "
+                f"Model package id: {model_package['id']}, "
+                f"Exception: {str(ex)}."
+            ) from ex
+        else:
+            logging_level, msg = self._report_runtime_deployment_logs_if_any(deployment_id)
+            if logging_level in (logging.WARNING, logging.ERROR):
+                raise DataRobotClientError(
+                    "A deployment reported a warning or an error. Stopping. "
+                    f"DataRobot deployment id: {deployment_id}, "
+                    f"User provided deployment id: {deployment_info.user_provided_id}, "
+                    f"Model package id: {model_package['id']}, "
+                    f"Message: {msg}"
+                )
+            response = self._http_requester.get(location, raw=True)
+            deployment = response.json()
+            return deployment
+
+    def _report_persistent_deployment_logs_if_any(self, deployment_id):
+        deployment_log_url = self.CUSTOM_MODEL_DEPLOYMENT_LOG_ROUTE.format(
+            deployment_id=deployment_id
         )
-        response = self._http_requester.get(location, raw=True)
-        return response.json()
+        response = self._http_requester.get(deployment_log_url)
+        if response.status_code == 200 and response.text:
+            logger.error(response.text)
+
+    def _report_runtime_deployment_logs_if_any(self, deployment_id):
+        deployment_log_url = self.CUSTOM_MODEL_DEPLOYMENT_LOG_ROUTE.format(
+            deployment_id=deployment_id
+        )
+        response = self._http_requester.post(deployment_log_url)
+        if response.status_code == 202:
+            location = self._wait_for_async_resolution(response.headers["Location"])
+            response = self._http_requester.get(location, raw=True)
+            if response.status_code == 200 and response.text:
+                if "WARNING" in response.text:
+                    logger.warning(response.text)
+                    return logging.WARNING, response.text
+                if "ERROR" in response.text:
+                    logger.error(response.text)
+                    return logging.ERROR, response.text
+                return logging.INFO, logger.info(response.text)
+        return None, None
 
     def _get_prediction_environment_id(self, model_package, deployment_info):
         prediction_environment_name = deployment_info.get_value(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
When there’s an error in a deployment creation from a package, is it desired to print the actual logs that might reveal the root cause of the failure. So, in such failure is it required to make a best effort to fetch and print such logs.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* When creating a deployment, fetch deployment runtime and persistent errors.
* Functional test

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
