### PR TITLE
[RAPTOR-9300] Properly trigger custom model testing even upon a change in the test section only

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -981,9 +981,16 @@ class DrClient:
 
         return check_params
 
-    def fetch_custom_model_tests(self, custom_model_id):
+    def fetch_custom_model_tests(self, custom_model_id, **kwargs):
         """
         Retrieve custom model tests from DataRobot.
+
+        Parameters
+        ----------
+        custom_model_id : str
+            A DataRobot custom inference model ID.
+        kwargs : dict
+            A key-value pairs to be submitted as additional attributes when querying DataRobot.
 
         Returns
         -------
@@ -993,6 +1000,8 @@ class DrClient:
 
         logger.debug("Fetching custom model tests for DataRobot model ID %s", custom_model_id)
         params = {"customModelId": custom_model_id}
+        if kwargs:
+            params.update(kwargs)
         return self._paginated_fetch(self.CUSTOM_MODELS_TEST_ROUTE, params=params)
 
     def upload_dataset(self, dataset_filepath):

--- a/tests/functional/test_deployment_github_actions.py
+++ b/tests/functional/test_deployment_github_actions.py
@@ -733,6 +733,7 @@ class TestDeploymentGitHubActions:
                         workspace_path, git_repo, main_branch_name, "push", is_deploy=True
                     )
 
+            printout(str(exec_info.value))
             assert any(record.levelname in ("WARNING", "ERROR") for record in caplog.records)
             assert "WARNING" in str(exec_info.value) or "WARNING" in str(exec_info.value)
         printout("Done")

--- a/tests/functional/test_model_github_actions.py
+++ b/tests/functional/test_model_github_actions.py
@@ -75,6 +75,9 @@ class TestModelGitHubActions:
         executed from a pull request branch with multiple commits.
         """
 
+        printout("Create models as a prerequisite for this test ...")
+        run_github_action(workspace_path, git_repo, main_branch_name, "push", is_deploy=False)
+
         printout("Create a feature branch ...")
         feature_branch = git_repo.create_head(feature_branch_name)
         checks = [self._increase_memory_check, self._add_file_check, self._remove_file_check]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Given that a model metadata is not part of  the mode package (.e.g using exclude attribute), and the user creates a commit in which he only enables the custom model testing, make sure to run the custom model testing only if the given version was not tested yet.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Make sure to trigger a custom model testing even if it there was no changes in its settings nor a new version was created.


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
