### PR TITLE
[RAPTOR-9312] Add a missing mapping of Anomaly target type + refactoring

### DIFF
--- a/src/dr_api_attrs.py
+++ b/src/dr_api_attrs.py
@@ -15,12 +15,12 @@ from schema_validator import ModelSchema
 CUSTOM_MODEL_TYPE = "inference"
 
 
-class DrApiAttrs:  # pylint: disable=too-few-public-methods
+class DrApiCustomModelChecks:  # pylint: disable=too-few-public-methods
     """
-    Contains mappings between local and DataRobot attributes.
+    Contains mappings between local custom model checks (testing) and DataRobot attributes.
     """
 
-    DR_TEST_CHECK_MAP = {
+    MAPPING = {
         ModelSchema.NULL_VALUE_IMPUTATION_KEY: "nullValueImputation",
         ModelSchema.SIDE_EFFECTS_KEY: "sideEffects",
         ModelSchema.PREDICTION_VERIFICATION_KEY: "predictionVerificationCheck",
@@ -29,7 +29,7 @@ class DrApiAttrs:  # pylint: disable=too-few-public-methods
     }
 
     @classmethod
-    def to_dr_test_check(cls, check_name):
+    def to_dr_attr(cls, check_name):
         """
         A method to map between local attribute test name to DataRobot related test name.
 
@@ -43,7 +43,7 @@ class DrApiAttrs:  # pylint: disable=too-few-public-methods
             DataRobot related test name.
 
         """
-        return cls.DR_TEST_CHECK_MAP[check_name]
+        return cls.MAPPING[check_name]
 
 
 class DrApiModelSettings:  # pylint: disable=too-few-public-methods
@@ -86,6 +86,31 @@ class DrApiModelSettings:  # pylint: disable=too-few-public-methods
     UNSTRUCTURED_TRAINING_HOLDOUT_MAPPING = {
         ModelSchema.TRAINING_DATASET_ID_KEY: "trainingDatasetId",
         ModelSchema.HOLDOUT_DATASET_ID_KEY: "holdoutDatasetId",
+    }
+
+    @classmethod
+    def to_dr_attr(cls, local_schema_key):
+        """
+        Maps between local schema settings attribute to the corresponding attribute in DataRobot.
+        """
+
+        return cls.MAPPING[local_schema_key]
+
+
+class DrApiTargetType:  # pylint: disable=too-few-public-methods
+    """
+    Contains mappings between local target types and DataRobot attributes.
+    """
+
+    MAPPING = {
+        ModelSchema.TARGET_TYPE_BINARY_KEY: "Binary",
+        ModelSchema.TARGET_TYPE_UNSTRUCTURED_BINARY_KEY: "Binary",
+        ModelSchema.TARGET_TYPE_REGRESSION_KEY: "Regression",
+        ModelSchema.TARGET_TYPE_UNSTRUCTURED_REGRESSION_KEY: "Regression",
+        ModelSchema.TARGET_TYPE_MULTICLASS_KEY: "Multiclass",
+        ModelSchema.TARGET_TYPE_UNSTRUCTURED_MULTICLASS_KEY: "Multiclass",
+        ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER_KEY: "Unstructured",
+        ModelSchema.TARGET_TYPE_ANOMALY_DETECTION_KEY: "Anomaly",
     }
 
     @classmethod

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -26,8 +26,9 @@ from common.exceptions import IllegalModelDeletion
 from common.http_requester import HttpRequester
 from common.namepsace import Namespace
 from common.string_util import StringUtil
-from dr_api_attrs import DrApiAttrs
+from dr_api_attrs import DrApiCustomModelChecks
 from dr_api_attrs import DrApiModelSettings
+from dr_api_attrs import DrApiTargetType
 from schema_validator import DeploymentSchema
 from schema_validator import ModelSchema
 
@@ -66,16 +67,6 @@ class DrClient:
     DEPLOYMENT_MODEL_CHALLENGER_ROUTE = DEPLOYMENT_ROUTE + "challengers/"
     DEPLOYMENT_ACTUALS_UPDATE_ROUTE = DEPLOYMENT_ROUTE + "actuals/fromDataset/"
     ENVIRONMENT_DROP_IN_ROUTE = "executionEnvironments/"
-
-    MODEL_TARGET_TYPE_MAP = {
-        ModelSchema.TARGET_TYPE_BINARY_KEY: "Binary",
-        ModelSchema.TARGET_TYPE_UNSTRUCTURED_BINARY_KEY: "Binary",
-        ModelSchema.TARGET_TYPE_REGRESSION_KEY: "Regression",
-        ModelSchema.TARGET_TYPE_UNSTRUCTURED_REGRESSION_KEY: "Regression",
-        ModelSchema.TARGET_TYPE_MULTICLASS_KEY: "Multiclass",
-        ModelSchema.TARGET_TYPE_UNSTRUCTURED_MULTICLASS_KEY: "Multiclass",
-        ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER_KEY: "Unstructured",
-    }
 
     DEFAULT_MAX_WAIT_SEC = 600
 
@@ -242,7 +233,7 @@ class DrClient:
 
         payload = {
             "customModelType": constants.CUSTOM_MODEL_TYPE,
-            "targetType": cls.MODEL_TARGET_TYPE_MAP.get(target_type),
+            "targetType": DrApiTargetType.to_dr_attr(target_type),
             "targetName": model_info.get_settings_value(ModelSchema.TARGET_NAME_KEY),
             "isUnstructuredModelKind": model_info.is_unstructured,
             "userProvidedId": model_info.get_value(ModelSchema.MODEL_ID_KEY),
@@ -897,7 +888,7 @@ class DrClient:
             "longRunningService": "fail",
             "errorCheck": "fail",
         }
-        for local_check_name, dr_check_name in DrApiAttrs.DR_TEST_CHECK_MAP.items():
+        for local_check_name, dr_check_name in DrApiCustomModelChecks.MAPPING.items():
             check_config_value = "skip"
             if loaded_checks:
                 check_info = loaded_checks.get(local_check_name)
@@ -925,7 +916,7 @@ class DrClient:
                     check_params.update(cls._get_stability_check_params(info))
 
                 if check_params:
-                    dr_check_name = DrApiAttrs.to_dr_test_check(check)
+                    dr_check_name = DrApiCustomModelChecks.to_dr_attr(check)
                     parameters[dr_check_name] = check_params
         return parameters
 

--- a/tests/unit/test_dr_api_attrs.py
+++ b/tests/unit/test_dr_api_attrs.py
@@ -1,0 +1,55 @@
+#  Copyright (c) 2023. DataRobot, Inc. and its affiliates.
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+
+
+"""
+A module to test the mapping between local schema attribute values to their corresponding attribute
+values in DataRobot API.
+"""
+from schema import Optional
+
+from dr_api_attrs import DrApiCustomModelChecks
+from dr_api_attrs import DrApiModelSettings
+from dr_api_attrs import DrApiTargetType
+from schema_validator import ModelSchema
+
+
+class TestDrApiAttrsMappings:
+    """
+    A class that contains unit-tests for attribute mappings between local schema and DataRboto
+    public API.
+    """
+
+    def test_custom_model_checks_mapping(self):
+        """
+        A case to test model check attributes correlation between local and DataRobot API.
+        """
+
+        local_optional_checks = ModelSchema.MODEL_SCHEMA.schema[Optional(ModelSchema.TEST_KEY)][
+            Optional(ModelSchema.CHECKS_KEY)
+        ]
+        for local_optional_check in local_optional_checks:
+            assert DrApiCustomModelChecks.to_dr_attr(local_optional_check.schema)
+
+    def test_model_settings_mapping(self):
+        """
+        A case to test model settings attributes correlation between local and DataRobot API.
+        """
+
+        local_setting_keys = ModelSchema.MODEL_SCHEMA.schema[ModelSchema.SETTINGS_SECTION_KEY]
+        for local_setting_key in local_setting_keys:
+            if isinstance(local_setting_key, Optional):
+                assert DrApiModelSettings.to_dr_attr(local_setting_key.schema)
+            else:
+                assert DrApiModelSettings.to_dr_attr(local_setting_key)
+
+    def test_target_type_mapping(self):
+        """
+        A case to test target type attributes correlation between local and DataRobot API.
+        """
+
+        local_target_types = ModelSchema.MODEL_SCHEMA.schema[ModelSchema.TARGET_TYPE_KEY].args
+        for local_target_type in local_target_types:
+            assert DrApiTargetType.to_dr_attr(local_target_type)

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -25,7 +25,7 @@ from common.exceptions import DataRobotClientError
 from common.http_requester import HttpRequester
 from common.namepsace import Namespace
 from deployment_info import DeploymentInfo
-from dr_api_attrs import DrApiAttrs
+from dr_api_attrs import DrApiCustomModelChecks
 from dr_api_attrs import DrApiModelSettings
 from dr_client import DrClient
 from dr_client import logger as dr_client_logger
@@ -935,7 +935,8 @@ class TestCustomModelVersionRoutes:
 
             configuration = DrClient._build_tests_configuration(partial_configuration)
             assert (
-                DrApiAttrs.to_dr_test_check(ModelSchema.NULL_VALUE_IMPUTATION_KEY) in configuration
+                DrApiCustomModelChecks.to_dr_attr(ModelSchema.NULL_VALUE_IMPUTATION_KEY)
+                in configuration
             )
             # The following checks are silently added
             for check in ["longRunningService", "errorCheck"]:
@@ -944,10 +945,10 @@ class TestCustomModelVersionRoutes:
         def test_full_custom_model_testing_configuration(self, mock_full_custom_model_checks):
             """A case to test a full configuration of custom model testing."""
 
-            assert mock_full_custom_model_checks.keys() == DrApiAttrs.DR_TEST_CHECK_MAP.keys()
+            assert mock_full_custom_model_checks.keys() == DrApiCustomModelChecks.MAPPING.keys()
             configuration = DrClient._build_tests_configuration(mock_full_custom_model_checks)
-            for check in DrApiAttrs.DR_TEST_CHECK_MAP:
-                assert DrApiAttrs.to_dr_test_check(check) in configuration
+            for check in DrApiCustomModelChecks.MAPPING:
+                assert DrApiCustomModelChecks.to_dr_attr(check) in configuration
             for check in ["longRunningService", "errorCheck"]:
                 assert check in configuration
 
@@ -959,7 +960,7 @@ class TestCustomModelVersionRoutes:
             disabled.
             """
 
-            assert mock_full_custom_model_checks.keys() == DrApiAttrs.DR_TEST_CHECK_MAP.keys()
+            assert mock_full_custom_model_checks.keys() == DrApiCustomModelChecks.MAPPING.keys()
             for _, info in mock_full_custom_model_checks.items():
                 info[ModelSchema.CHECK_ENABLED_KEY] = False
             configuration = DrClient._build_tests_configuration(mock_full_custom_model_checks)
@@ -968,9 +969,9 @@ class TestCustomModelVersionRoutes:
         def test_full_custom_model_testing_parameters(self, mock_full_custom_model_checks):
             """A case to test a full number of parameters in custom model testing."""
 
-            assert mock_full_custom_model_checks.keys() == DrApiAttrs.DR_TEST_CHECK_MAP.keys()
+            assert mock_full_custom_model_checks.keys() == DrApiCustomModelChecks.MAPPING.keys()
             parameters = DrClient._build_tests_parameters(mock_full_custom_model_checks)
-            dr_stability_check_key = DrApiAttrs.to_dr_test_check(ModelSchema.STABILITY_KEY)
+            dr_stability_check_key = DrApiCustomModelChecks.to_dr_attr(ModelSchema.STABILITY_KEY)
 
             assert (
                 parameters[dr_stability_check_key]["passingRate"]
@@ -985,7 +986,7 @@ class TestCustomModelVersionRoutes:
                 ModelSchema.PERFORMANCE_KEY,
                 ModelSchema.STABILITY_KEY,
             ]:
-                assert DrApiAttrs.to_dr_test_check(check) in parameters
+                assert DrApiCustomModelChecks.to_dr_attr(check) in parameters
 
         def test_full_custom_model_testing_parameters_with_all_disabled_checks(
             self, mock_full_custom_model_checks
@@ -994,7 +995,7 @@ class TestCustomModelVersionRoutes:
             A case to test a full number of testing parameters, when all the checks are disabled.
             """
 
-            assert mock_full_custom_model_checks.keys() == DrApiAttrs.DR_TEST_CHECK_MAP.keys()
+            assert mock_full_custom_model_checks.keys() == DrApiCustomModelChecks.MAPPING.keys()
             for _, info in mock_full_custom_model_checks.items():
                 info[ModelSchema.CHECK_ENABLED_KEY] = False
             parameters = DrClient._build_tests_parameters(mock_full_custom_model_checks)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
When creating a new custom model, the action maps the TARGET_TYPE values from ModelSchema to values that are expected from the API. This done via MODEL_TARGET_TYPE_MAP in dr_client.py.

The Type map was missing a mapping for Anomaly Detection models. Thus, when using Anomaly Detection as the target type no value was passed to the API leading to an error.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add missing mapping attribute to the target type
* Some refactoring concerning mappings between local schema attributes to DataRobot API.

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
