### PR TITLE
[RAPTOR-9319] Add support for multi-lines output message metric 

### DIFF
--- a/src/common/github_env.py
+++ b/src/common/github_env.py
@@ -6,6 +6,7 @@
 """A module to provide an interface to GitHub environment variables"""
 
 import os
+import uuid
 from pathlib import Path
 
 
@@ -78,5 +79,16 @@ class GitHubEnv:
     def set_output_param(cls, name, value):
         """Set an output parameter that can be referenced by a follow-up step."""
 
+        is_multiline = False
+        if isinstance(value, str):
+            value = value.rstrip()
+            is_multiline = "\n" in value
+
         with open(cls.github_output(), "a", encoding="utf-8") as file:
-            file.write(f"{name}={value}\n")
+            if is_multiline:
+                eof = uuid.uuid4()
+                file.write(f"{name}<<{eof}\n")
+                file.write(f"{value}\n")
+                file.write(f"{eof}\n")
+            else:
+                file.write(f"{name}={value}\n")

--- a/tests/unit/test_dr_api_attrs.py
+++ b/tests/unit/test_dr_api_attrs.py
@@ -41,9 +41,31 @@ class TestDrApiAttrsMappings:
         local_setting_keys = ModelSchema.MODEL_SCHEMA.schema[ModelSchema.SETTINGS_SECTION_KEY]
         for local_setting_key in local_setting_keys:
             if isinstance(local_setting_key, Optional):
-                assert DrApiModelSettings.to_dr_attr(local_setting_key.schema)
+                local_name = local_setting_key.schema
             else:
-                assert DrApiModelSettings.to_dr_attr(local_setting_key)
+                local_name = local_setting_key
+
+            remote_key = DrApiModelSettings.to_dr_attr(local_name)
+            if remote_key == DrApiModelSettings.ReservedValues.UNSET:
+                remote_key = DrApiModelSettings.STRUCTURED_TRAINING_HOLDOUT_PATCH_MAPPING.get(
+                    local_name
+                )
+                if not remote_key:
+                    remote_key = DrApiModelSettings.UNSTRUCTURED_TRAINING_HOLDOUT_MAPPING.get(
+                        local_name
+                    )
+                    assert remote_key, f"Missing local '{local_name}' key mapping!"
+
+    def test_dr_structured_model_training_holdout_response_and_patch_keys(self):
+        """
+        Test the correlation between response and patch payloads of the training/holdout data in
+        structured models.
+        """
+
+        response_mapping = DrApiModelSettings.STRUCTURED_TRAINING_HOLDOUT_RESPONSE_MAPPING
+        patch_mapping = DrApiModelSettings.STRUCTURED_TRAINING_HOLDOUT_PATCH_MAPPING
+        for local_key, _ in response_mapping.items():
+            assert patch_mapping.get(local_key) is not None
 
     def test_target_type_mapping(self):
         """


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Apparently, all the functional tests pass with success, but eventually GitHub the following errors:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '-------- custom-model logs --------'
```

This is because GitHub deprecated an old way to output metrics and replaced it with a method that requires special handling to output multi-lines.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Extend the GitHubEnv::set_output_param to support multlines string value.
* Unit tests

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
