### PR TITLE
[RAPTOR-9337] Temporarily disable assignment of training/holdout data at model version level

### DIFF
--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -305,9 +305,9 @@ class ModelSchema(SharedSchema):
                 ),
                 Optional(MEMORY_KEY): Use(MemoryConvertor.to_bytes),
                 Optional(REPLICAS_KEY): And(int, lambda r: r > 0),
-                Optional(PARTITIONING_COLUMN_KEY): And(str, len),
-                Optional(TRAINING_DATASET_ID_KEY): And(str, ObjectId.is_valid),
-                Optional(HOLDOUT_DATASET_ID_KEY): And(str, ObjectId.is_valid),
+                # Optional(PARTITIONING_COLUMN_KEY): And(str, len),
+                # Optional(TRAINING_DATASET_ID_KEY): And(str, ObjectId.is_valid),
+                # Optional(HOLDOUT_DATASET_ID_KEY): And(str, ObjectId.is_valid),
             },
             Optional(TEST_KEY): {
                 # The skip attribute allows users to have the test section in their yaml file

--- a/tests/functional/test_deployment_github_actions.py
+++ b/tests/functional/test_deployment_github_actions.py
@@ -417,7 +417,7 @@ class TestDeploymentGitHubActions:
         """An end-to-end case to test changes in deployment settings."""
 
         with temporarily_upload_training_dataset_for_structured_model(
-            dr_client, model_metadata_yaml_file, is_model_level=False, event_name=event_name
+            dr_client, model_metadata_yaml_file, is_model_level=True, event_name=event_name
         ):
             try:
                 # Run the GitHub action to create a model and deployment

--- a/tests/functional/test_model_training_holdout_data.py
+++ b/tests/functional/test_model_training_holdout_data.py
@@ -129,6 +129,7 @@ class TestModelTrainingHoldoutData:
         versions = dr_client.fetch_custom_model_versions(custom_model["id"])
         assert len(versions) == 1
 
+    @pytest.makr.skip(reason="Training/holdout data is not supported at version level, just yet.")
     def test_e2e_set_training_and_holdout_datasets_for_structured_model_version(
         self,
         dr_client,

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -237,6 +237,9 @@ class TestModelSchemaValidator:
         attributes.
         """
 
+        if section == ModelSchema.VERSION_KEY:
+            pytest.skip("Training/holdout data are still not supported at version level.")
+
         model_metadata = create_partial_model_schema(is_single, num_models=1, with_target_type=True)
 
         edit_metadata = (
@@ -253,6 +256,7 @@ class TestModelSchemaValidator:
             else:
                 ModelSchema.validate_and_transform_multi(model_metadata)
 
+    @pytest.mark.skip(reason="Training/holdout data is currently not supported at version level.")
     @pytest.mark.parametrize("is_single", [True, False], ids=["single", "multi"])
     @pytest.mark.parametrize("is_unstructured", [True, False], ids=["unstructured", "structured"])
     @pytest.mark.parametrize("with_holdout", [True, False], ids=["with-holdout", "without-holdout"])


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Apparently, the related public APIs are in a deprecation phase and instead a work is being done to assign training/holdout data as part of a model version creation/update. In order not to enforce the current API to go into the regular deprecation process, it is required to disable the usage of them. 

Soon the new APIs will be ready and some more work will be required in the GitHub action to remove the old once and start using the new ones.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Comment out the training/holdout attributes in the model's schema version section.
* For the basic functional test, set the training/holdout data at the model level
* Disable certain related unit-tests
* Disable certain related functional-test

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
