### PR TITLE
[RAPTOR-9299] Enable users to specify the reason for a model replacement in a deployment

### DIFF
--- a/src/deployment_controller.py
+++ b/src/deployment_controller.py
@@ -205,8 +205,13 @@ class DeploymentController(ControllerBase):
                             deployment_info,
                         )
                     else:
+                        associated_model_info = self._model_controller.models_info.get(
+                            deployment_info.user_provided_model_id
+                        )
                         self._replace_model_version_in_deployment(
-                            desired_datarobot_model.latest_version, datarobot_deployment
+                            associated_model_info,
+                            desired_datarobot_model.latest_version,
+                            datarobot_deployment,
                         )
                         self._reapply_deployment_settings_upon_model_replacement(
                             deployment_info, datarobot_deployment
@@ -279,7 +284,9 @@ class DeploymentController(ControllerBase):
     def _there_is_a_new_model_version(datarobot_model, datarobot_deployment):
         return datarobot_deployment.model_version["id"] != datarobot_model.latest_version["id"]
 
-    def _replace_model_version_in_deployment(self, model_latest_version, datarobot_deployment):
+    def _replace_model_version_in_deployment(
+        self, model_info, model_latest_version, datarobot_deployment
+    ):
         user_provided_id = datarobot_deployment.deployment["userProvidedId"]
         logger.info(
             "Replacing a model version in a deployment ... "
@@ -288,7 +295,7 @@ class DeploymentController(ControllerBase):
             model_latest_version["id"],
         )
         deployment = self._dr_client.replace_model_deployment(
-            model_latest_version, datarobot_deployment
+            model_info, model_latest_version, datarobot_deployment
         )
         logger.info(
             "The latest model version was successfully replaced in a deployment. "

--- a/src/deployment_info.py
+++ b/src/deployment_info.py
@@ -21,6 +21,12 @@ class DeploymentInfo(InfoBase):
         self._metadata = deployment_metadata
 
     @property
+    def schema_validator(self):
+        """Return the schema validator class."""
+
+        return DeploymentSchema
+
+    @property
     def user_provided_id(self):
         """
         A deployment's unique ID that is provided by the user and read from the deployment's
@@ -53,86 +59,3 @@ class DeploymentInfo(InfoBase):
         challenger_enabled = self.get_settings_value(DeploymentSchema.ENABLE_CHALLENGER_MODELS_KEY)
         # A special case, in which the default is to enable challengers
         return True if challenger_enabled is None else challenger_enabled
-
-    def get_value(self, key, *sub_keys):
-        """
-        Get a value from the deployment's metadata given a key and sub-keys.
-
-        Parameters
-        ----------
-        key : str
-            A key name from the DeploymentSchema.
-        sub_keys :
-            An optional dynamic sub-keys from the DeploymentSchema.
-
-        Returns
-        -------
-        Any or None,
-            The value associated with the provided key (and sub-keys) or None if not exists.
-        """
-
-        return DeploymentSchema.get_value(self.metadata, key, *sub_keys)
-
-    def set_value(self, key, *sub_keys, value):
-        """
-        Set a value in the deployment's metadata.
-
-        Parameters
-        ----------
-        key : str
-            A key name from the DeploymentSchema.
-        sub_keys : list
-            An optional dynamic sub-keys from the DeploymentSchema.
-        value : Any
-            A value to set for the given key and optionally sub keys.
-
-        Returns
-        -------
-        dict,
-            The revised metadata after the value was set.
-        """
-
-        return DeploymentSchema.set_value(self.metadata, key, *sub_keys, value=value)
-
-    def get_settings_value(self, key, *sub_keys):
-        """
-        Get a value from the deployment's metadata settings section, given a key and sub-keys
-        under the settings section.
-
-        Parameters
-        ----------
-        key : str
-            A key name from the DeploymentSchema, which is supposed to be under the
-            SharedSchema.SETTINGS_SECTION_KEY section.
-        sub_keys :
-            An optional dynamic sub-keys from the DeploymentSchema, which are under the
-            SharedSchema.SETTINGS_SECTION_KEY section.
-
-        Returns
-        -------
-        Any or None,
-            The value associated with the provided key (and sub-keys) or None if not exists.
-        """
-
-        return self.get_value(DeploymentSchema.SETTINGS_SECTION_KEY, key, *sub_keys)
-
-    def set_settings_value(self, key, *sub_keys, value):
-        """
-        Set a value in the self deployment's metadata settings section.
-
-        Parameters
-        ----------
-        key : str
-            A key from the SharedSchema.SETTINGS_SECTION_KEY.
-        sub_keys: list
-            An optional dynamic sub-keys from the DeploymentSchema.
-        value : Any
-            A value to set.
-
-        Returns
-        -------
-        dict,
-            The revised metadata after the value was set.
-        """
-
-        return self.set_value(DeploymentSchema.SETTINGS_SECTION_KEY, key, *sub_keys, value=value)

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -244,6 +244,15 @@ class ModelSchema(SharedSchema):
     MEMORY_KEY = "memory"
     REPLICAS_KEY = "replicas"
 
+    MODEL_REPLACEMENT_REASON_KEY = "model_replacement_reason"
+    MODEL_REPLACEMENT_REASON_ACCURACY = "ACCURACY"
+    MODEL_REPLACEMENT_REASON_DATA_DRIFT = "DATA_DRIFT"
+    MODEL_REPLACEMENT_REASON_ERRORS = "ERRORS"
+    MODEL_REPLACEMENT_REASON_SCHEDULED_REFRESH = "SCHEDULED_REFRESH"
+    MODEL_REPLACEMENT_REASON_SCORING_SPEED = "SCORING_SPEED"
+    MODEL_REPLACEMENT_REASON_DEPRECATION = "DEPRECATION"
+    MODEL_REPLACEMENT_REASON_OTHER = "OTHER"
+
     TEST_KEY = "test"
     TEST_SKIP_KEY = "skip"
     TEST_DATA_ID_KEY = "test_data_id"
@@ -308,6 +317,15 @@ class ModelSchema(SharedSchema):
                 # Optional(PARTITIONING_COLUMN_KEY): And(str, len),
                 # Optional(TRAINING_DATASET_ID_KEY): And(str, ObjectId.is_valid),
                 # Optional(HOLDOUT_DATASET_ID_KEY): And(str, ObjectId.is_valid),
+                Optional(MODEL_REPLACEMENT_REASON_KEY, default=MODEL_REPLACEMENT_REASON_OTHER): Or(
+                    MODEL_REPLACEMENT_REASON_ACCURACY,
+                    MODEL_REPLACEMENT_REASON_DATA_DRIFT,
+                    MODEL_REPLACEMENT_REASON_ERRORS,
+                    MODEL_REPLACEMENT_REASON_SCHEDULED_REFRESH,
+                    MODEL_REPLACEMENT_REASON_SCORING_SPEED,
+                    MODEL_REPLACEMENT_REASON_DEPRECATION,
+                    MODEL_REPLACEMENT_REASON_OTHER,
+                ),
             },
             Optional(TEST_KEY): {
                 # The skip attribute allows users to have the test section in their yaml file

--- a/tests/functional/test_deployment_github_actions.py
+++ b/tests/functional/test_deployment_github_actions.py
@@ -26,10 +26,12 @@ from common.namepsace import Namespace
 from deployment_info import DeploymentInfo
 from metrics import Metrics
 from schema_validator import DeploymentSchema
+from schema_validator import ModelSchema
 from tests.conftest import unique_str
 from tests.functional.conftest import cleanup_models
 from tests.functional.conftest import increase_model_memory_by_1mb
 from tests.functional.conftest import printout
+from tests.functional.conftest import replace_and_store_schema
 from tests.functional.conftest import run_github_action
 from tests.functional.conftest import save_new_metadata_and_commit
 from tests.functional.conftest import temporarily_replace_schema
@@ -253,7 +255,19 @@ class TestDeploymentGitHubActions:
             git_repo, model_metadata_yaml_file, do_commit=False
         )
 
-        cls._commit_changes_by_event(f"Increase memory to {new_memory}", event_name, git_repo)
+        # Set the reason for the replacement
+        replace_and_store_schema(
+            model_metadata_yaml_file,
+            ModelSchema.VERSION_KEY,
+            ModelSchema.MODEL_REPLACEMENT_REASON_KEY,
+            metadata_or_value=ModelSchema.MODEL_REPLACEMENT_REASON_ERRORS,
+        )
+
+        cls._commit_changes_by_event(
+            f"Increase memory to {new_memory} and update the reason for replacement",
+            event_name,
+            git_repo,
+        )
 
         # Run the GitHub action to replace the latest model in a deployment
         printout(f"Run the GitHub action ({event_name} event)")

--- a/tests/functional/test_model_training_holdout_data.py
+++ b/tests/functional/test_model_training_holdout_data.py
@@ -129,7 +129,7 @@ class TestModelTrainingHoldoutData:
         versions = dr_client.fetch_custom_model_versions(custom_model["id"])
         assert len(versions) == 1
 
-    @pytest.makr.skip(reason="Training/holdout data is not supported at version level, just yet.")
+    @pytest.mark.skip(reason="Training/holdout data is not supported at version level, just yet.")
     def test_e2e_set_training_and_holdout_datasets_for_structured_model_version(
         self,
         dr_client,
@@ -391,6 +391,7 @@ class TestModelTrainingHoldoutData:
         ) as holdout_dataset_id:
             yield training_dataset_id, holdout_dataset_id
 
+    @pytest.mark.skip(reason="Training/holdout data is not supported at version level, just yet.")
     def test_e2e_set_training_and_holdout_datasets_for_unstructured_model_version(
         self,
         dr_client,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Until this PR, the reason for replacing a model was hard-coded with a value of "OTHER". With this PR the user can specify the reason for a model's replacement in a deployment by using a specific attribute in the model's metadata YAML file.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add a new attribute to the model's schema: `model_replacement_reason`, which can be set with very specific values.
* Some refactoring
* Spelling bug + skip specific undesired functional test
* Unit & functional tests


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
