### PR TITLE
[RAPTOR-9448] Fix the issue of params arguments that are concatenated to the URL at every paginated call

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -171,6 +171,10 @@ class DrClient:
 
     def _paginated_fetch(self, route_url, **kwargs):
         def _fetch_single_page(url, raw):
+            if raw:
+                # 'params' are added to the url in the form of '&attr=value', so we want to skip
+                # it in case it is a 'raw' call that should not alter the url.
+                kwargs.pop("params", None)
             response = self._http_requester.get(url, raw, **kwargs)
             if response.status_code != 200:
                 raise DataRobotClientError(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
When fetching entities from DataRobot usually a pagination takes place. The client (GH Action) uses the ‘next’ field to call the followed page url. The url in the 'next' field should not be altered and the call should use it as is. The issue is that the ‘params’ argument is also passed to the request.get method, which result in concatenation of the params to the URL.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Fix the DrClient pagination method.

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
