### PR TITLE
[RAPTOR-9449] Validate that a model's definition is not deleted in a PR while it is deployed

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -565,11 +565,11 @@ def skip_model_testing(git_repo, numbered_model_metadata, numbered_model_metadat
             model_metadata_yaml_file = numbered_model_metadata_yaml_file(model_number)
             save_new_metadata(model_metadata, model_metadata_yaml_file)
             git_repo.git.add(model_metadata_yaml_file)
+
+        git_repo.git.commit("-m", "Restore model(s) testing section")
     except StopIteration:
         # It's a kind of best-effort operation. The test may change the models' hierarchy.
         pass
-
-    git_repo.git.commit("-m", "Restore model(s) testing section")
 
 
 # NOTE: it was rather better to use the pytest.mark.usefixture for 'build_repo_for_testing'

--- a/tests/unit/test_custom_inference_deployment.py
+++ b/tests/unit/test_custom_inference_deployment.py
@@ -429,12 +429,17 @@ class TestCustomInferenceDeployment:
             with self._mock_repo_with_datarobot_models(
                 deployments_factory, git_repo, init_repo_for_root_path_factory
             ):
-                git_tool = GitTool(GitHubEnv.workspace_path())
-                model_controller = ModelController(options, git_tool)
-                deployment_controller = DeploymentController(options, model_controller, git_tool)
-                deployment_controller.scan_and_load_deployments_metadata()
-                deployment_controller.fetch_deployments_from_datarobot()
-                deployment_controller.validate_deployments_integrity()
+                self._setup_and_run_deployment_integrity_validation(options)
+
+    @staticmethod
+    def _setup_and_run_deployment_integrity_validation(options):
+        git_tool = GitTool(GitHubEnv.workspace_path())
+        model_controller = ModelController(options, git_tool)
+        model_controller.scan_and_load_models_metadata()
+        deployment_controller = DeploymentController(options, model_controller, git_tool)
+        deployment_controller.scan_and_load_deployments_metadata()
+        deployment_controller.fetch_deployments_from_datarobot()
+        deployment_controller.validate_deployments_integrity()
 
     @pytest.mark.usefixtures("workspace_path")
     def test_deployments_integrity_validation_no_dr_deployments(
@@ -450,13 +455,7 @@ class TestCustomInferenceDeployment:
             init_repo_for_root_path_factory,
             with_dr_deployments=False,
         ):
-            git_tool = GitTool(GitHubEnv.workspace_path())
-            model_controller = ModelController(options, git_tool)
-            model_controller.scan_and_load_models_metadata()
-            deployment_controller = DeploymentController(options, model_controller, git_tool)
-            deployment_controller.scan_and_load_deployments_metadata()
-            deployment_controller.fetch_deployments_from_datarobot()
-            deployment_controller.validate_deployments_integrity()
+            self._setup_and_run_deployment_integrity_validation(options)
 
     @pytest.mark.usefixtures("no_deployments")
     def test_save_statistics(self, options, github_output):
@@ -502,14 +501,8 @@ class TestCustomInferenceDeployment:
             with_associated_dr_models=True,
             with_latest_dr_model_version=False,
         ):
-            git_tool = GitTool(GitHubEnv.workspace_path())
-            model_controller = ModelController(options, git_tool)
-            model_controller.scan_and_load_models_metadata()
-            deployment_controller = DeploymentController(options, model_controller, git_tool)
-            deployment_controller.scan_and_load_deployments_metadata()
-            deployment_controller.fetch_deployments_from_datarobot()
             with pytest.raises(AssociatedModelVersionNotFound):
-                deployment_controller.validate_deployments_integrity()
+                self._setup_and_run_deployment_integrity_validation(options)
 
     @pytest.mark.usefixtures("workspace_path")
     def test_deployments_integrity_validation_no_main_branch_sha_failure(
@@ -523,13 +516,8 @@ class TestCustomInferenceDeployment:
             init_repo_for_root_path_factory,
             with_main_branch_sha=False,
         ):
-            git_tool = GitTool(GitHubEnv.workspace_path())
-            model_controller = ModelController(options, git_tool)
-            deployment_controller = DeploymentController(options, model_controller, git_tool)
-            deployment_controller.scan_and_load_deployments_metadata()
-            deployment_controller.fetch_deployments_from_datarobot()
             with pytest.raises(NoValidAncestor):
-                deployment_controller.validate_deployments_integrity()
+                self._setup_and_run_deployment_integrity_validation(options)
 
 
 class TestDeploymentChanges:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
The user can delete a model’s definition and create a PR, even if the model is deployed. Because the checks will succeed, the PR can be merged, but the action will fail to delete the model in DataRobot. It is required to notify the user during the PR that the model is deployed and cannot be set for deletion without deleting its associated deployment definition.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Improve the validation check for deployments.


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
