### PR TITLE
[RAPTOR-9459] Fix a crash in case of missing holdout attributes

### DIFF
--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -805,10 +805,10 @@ class ModelController(ControllerBase):
                     "User provided ID: %s. Training dataset name: %s. Training dataset ID: %s. "
                     "Holdout dataset name: %s. Holdout dataset ID: %s",
                     model_info.user_provided_id,
-                    custom_model["externalMlopsStatsConfig"]["trainingDatasetName"],
-                    custom_model["externalMlopsStatsConfig"]["trainingDatasetId"],
-                    custom_model["externalMlopsStatsConfig"]["holdoutDatasetName"],
-                    custom_model["externalMlopsStatsConfig"]["holdoutDatasetId"],
+                    custom_model["externalMlopsStatsConfig"].get("trainingDatasetName"),
+                    custom_model["externalMlopsStatsConfig"].get("trainingDatasetId"),
+                    custom_model["externalMlopsStatsConfig"].get("holdoutDatasetName"),
+                    custom_model["externalMlopsStatsConfig"].get("holdoutDatasetId"),
                 )
         else:
             custom_model = self._dr_client.update_training_dataset_for_structured_models(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
The issue that there’s a printout log that access the holdout data information that is returned from DataRobot. These attributes are missing if they were not set.

## CHANGES
<!-- List the changes in this PR, in highlights. -->


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [x] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
