### PR TITLE
[RAPTOR-9559] Add support for egress network policy resource in a model version

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,17 +272,14 @@ steps in the same GitHub job (refer to the workflow example below):
 
 ### Model Definition
 
-The GitHub action requires the model's metadata in a YAML file. The model's full schema is defined in
-[this source code block](
-https://github.com/datarobot/custom-models-action/blob/62b9df9e8895becabd7592e65c0ed52252690498/src/schema_validator.py#L271
-)
+The GitHub action requires the model's metadata in a YAML file. The model's full schema is defined
+by `MODEL_SCHEMA`, which can be found in [here](src/schema_validator.py).
 
 A model metadata YAML file may contain the schema of a single model's definition
 (as specified above) or the schema of multiple models' definitions.
 
-The **multiple models' schema** is defined in [this source code block](
-https://github.com/datarobot/custom-models-action/blob/62b9df9e8895becabd7592e65c0ed52252690498/src/schema_validator.py#L351
-).
+The **multiple models' schema** is defined by `MULTI_MODELS_SCHEMA`, which can be found in
+[here](src/schema_validator.py).
 
 The single model's definition YAML file must be located inside the model's root directory.
 The multiple models' definition YAML file can be located anywhere in the repository.
@@ -316,16 +313,13 @@ At the top level, there are attributes you cannot change after a model is create
 ### Deployment Definition
 
 The user is required to provide the deployment's metadata in a YAML file. The deployment's full
-schema is defined in [this source code block](
-https://github.com/datarobot/custom-models-action/blob/62b9df9e8895becabd7592e65c0ed52252690498/src/schema_validator.py#L639
-).
+schema is defined by `DEPLOYMENT_SCHEMA`, which can be found in [here](src/schema_validator.py).
 
 A deployment metadata YAML file may contain the schema of a single deployment's definition (as
 specified above) or the schema of multiple deployments' definitions.
 
-The **multiple deployments' schema** is defined in [this source code block](
-https://github.com/datarobot/custom-models-action/blob/62b9df9e8895becabd7592e65c0ed52252690498/src/schema_validator.py#L679
-).
+The **multiple deployments' schema** is defined by `MULTI_DEPLOYMENTS_SCHEMA`, which can be
+found in [here](src/schema_validator.py).
 
 The deployment definition YAML file (single or multiple) can be located anywhere in
 the repository.
@@ -493,7 +487,8 @@ version:
 
 <details><summary>Full Single Model Definition</summary>
 
-Below is an example of a full model's definition, which includes both mandatory and optional fields:
+Below is an example of a full model's definition, which includes both mandatory and optional fields
+(for the full scheme please refer to `MODEL_SCHEMA` in [here](src/schema_validator.py)):
 
 ```yaml
 user_provided_model_id: user/any-model-unique-id-1
@@ -519,6 +514,7 @@ version:
     - ./
   memory: 256Mi
   replicas: 2
+  egress_network_policy: NONE
   model_replacement_reason: DATA_DRIFT
 
 test:
@@ -613,7 +609,7 @@ user_provided_model_id: user/any-model-unique-id-1
 <details><summary>Full Single Deployment Definition</summary>
 
 Below is an example of a full deployment's definition, which includes both mandatory and optional
-fields:
+fields (for the full schema please refer to `DEPLOYMENT_SCHEMA` in [here](src/schema_validator.py):
 
 ```yaml
 user_provided_deployment_id: user/my-awesome-deployment-id

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -490,6 +490,12 @@ class DrClient:
         if replicas:
             payload.append(("replicas", str(replicas)))
 
+        egress_network_policy = model_info.get_value(
+            ModelSchema.VERSION_KEY, ModelSchema.EGRESS_NETWORK_POLICY_KEY
+        )
+        if egress_network_policy:
+            payload.append(("networkEgressPolicy", str(egress_network_policy)))
+
         return payload, file_objs
 
     @staticmethod

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -300,13 +300,14 @@ class ModelInfo(InfoBase):
         ):
             return True
 
-        configured_memory = self.get_value(ModelSchema.VERSION_KEY, ModelSchema.MEMORY_KEY)
-        if configured_memory != datarobot_latest_model_version.get("maximumMemory"):
-            return True
-
-        configured_replicas = self.get_value(ModelSchema.VERSION_KEY, ModelSchema.REPLICAS_KEY)
-        if configured_replicas != datarobot_latest_model_version.get("replicas"):
-            return True
+        for resource_key, dr_attribute_key in (
+            (ModelSchema.MEMORY_KEY, "maximumMemory"),
+            (ModelSchema.REPLICAS_KEY, "replicas"),
+            (ModelSchema.EGRESS_NETWORK_POLICY_KEY, "networkEgressPolicy"),
+        ):
+            configured_resource = self.get_value(ModelSchema.VERSION_KEY, resource_key)
+            if configured_resource != datarobot_latest_model_version.get(dr_attribute_key):
+                return True
 
         return False
 

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -243,6 +243,9 @@ class ModelSchema(SharedSchema):
     EXCLUDE_GLOB_KEY = "exclude_glob_pattern"
     MEMORY_KEY = "memory"
     REPLICAS_KEY = "replicas"
+    EGRESS_NETWORK_POLICY_KEY = "egress_network_policy"
+    EGRESS_NETWORK_POLICY_NONE = "NONE"
+    EGRESS_NETWORK_POLICY_PUBLIC = "PUBLIC"
 
     MODEL_REPLACEMENT_REASON_KEY = "model_replacement_reason"
     MODEL_REPLACEMENT_REASON_ACCURACY = "ACCURACY"
@@ -314,6 +317,9 @@ class ModelSchema(SharedSchema):
                 ),
                 Optional(MEMORY_KEY): Use(MemoryConvertor.to_bytes),
                 Optional(REPLICAS_KEY): And(int, lambda r: r > 0),
+                Optional(EGRESS_NETWORK_POLICY_KEY): Or(
+                    EGRESS_NETWORK_POLICY_NONE, EGRESS_NETWORK_POLICY_PUBLIC
+                ),
                 # Optional(PARTITIONING_COLUMN_KEY): And(str, len),
                 # Optional(TRAINING_DATASET_ID_KEY): And(str, ObjectId.is_valid),
                 # Optional(HOLDOUT_DATASET_ID_KEY): And(str, ObjectId.is_valid),

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -493,6 +493,7 @@ def mock_full_binary_model_schema(mock_full_custom_model_checks):
             ModelSchema.EXCLUDE_GLOB_KEY: ["README.md", "out/"],
             ModelSchema.MEMORY_KEY: "100Mi",
             ModelSchema.REPLICAS_KEY: 3,
+            ModelSchema.EGRESS_NETWORK_POLICY_KEY: ModelSchema.EGRESS_NETWORK_POLICY_PUBLIC,
         },
         ModelSchema.TEST_KEY: {
             ModelSchema.TEST_DATA_ID_KEY: "62779143562155aa34a3d65b",

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -115,6 +115,7 @@ def fixture_regression_model_info():
             ModelSchema.EXCLUDE_GLOB_KEY: ["README.md", "out/"],
             ModelSchema.MEMORY_KEY: 256 * 1024 * 1024,
             ModelSchema.REPLICAS_KEY: 3,
+            ModelSchema.EGRESS_NETWORK_POLICY_KEY: ModelSchema.EGRESS_NETWORK_POLICY_PUBLIC,
         },
     }
     return ModelInfo(
@@ -895,6 +896,7 @@ class TestCustomModelVersionRoutes:
             assert "filePath" in keys
             assert "maximumMemory" in keys
             assert "replicas" in keys
+            assert "networkEgressPolicy" in keys
 
     def test_minimal_payload_setup_for_custom_model_version_creation(
         self, minimal_regression_model_info, git_model_version


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Lately, we added support for network egress policy in production. It is required to allow users to specify the policy for their custom models.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Add an egress network policy field to the model schema
* Add the egress network policy attribute when creating a custom model version
* Unit test
* Update README.md


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
