### PR TITLE
[RAPTOR-9562] Rename model/deployment value definitions by removing the '_KEY' suffix

### DIFF
--- a/src/dr_api_attrs.py
+++ b/src/dr_api_attrs.py
@@ -103,14 +103,14 @@ class DrApiTargetType:  # pylint: disable=too-few-public-methods
     """
 
     MAPPING = {
-        ModelSchema.TARGET_TYPE_BINARY_KEY: "Binary",
-        ModelSchema.TARGET_TYPE_UNSTRUCTURED_BINARY_KEY: "Binary",
-        ModelSchema.TARGET_TYPE_REGRESSION_KEY: "Regression",
-        ModelSchema.TARGET_TYPE_UNSTRUCTURED_REGRESSION_KEY: "Regression",
-        ModelSchema.TARGET_TYPE_MULTICLASS_KEY: "Multiclass",
-        ModelSchema.TARGET_TYPE_UNSTRUCTURED_MULTICLASS_KEY: "Multiclass",
-        ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER_KEY: "Unstructured",
-        ModelSchema.TARGET_TYPE_ANOMALY_DETECTION_KEY: "Anomaly",
+        ModelSchema.TARGET_TYPE_BINARY: "Binary",
+        ModelSchema.TARGET_TYPE_UNSTRUCTURED_BINARY: "Binary",
+        ModelSchema.TARGET_TYPE_REGRESSION: "Regression",
+        ModelSchema.TARGET_TYPE_UNSTRUCTURED_REGRESSION: "Regression",
+        ModelSchema.TARGET_TYPE_MULTICLASS: "Multiclass",
+        ModelSchema.TARGET_TYPE_UNSTRUCTURED_MULTICLASS: "Multiclass",
+        ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER: "Unstructured",
+        ModelSchema.TARGET_TYPE_ANOMALY_DETECTION: "Anomaly",
     }
 
     @classmethod

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -206,14 +206,14 @@ class ModelSchema(SharedSchema):
     MODEL_ENTRY_META_KEY = "model_metadata"
 
     TARGET_TYPE_KEY = "target_type"
-    TARGET_TYPE_BINARY_KEY = "Binary"
-    TARGET_TYPE_REGRESSION_KEY = "Regression"
-    TARGET_TYPE_MULTICLASS_KEY = "Multiclass"
-    TARGET_TYPE_ANOMALY_DETECTION_KEY = "Anomaly Detection"
-    TARGET_TYPE_UNSTRUCTURED_BINARY_KEY = "Unstructured (Binary)"
-    TARGET_TYPE_UNSTRUCTURED_REGRESSION_KEY = "Unstructured (Regression)"
-    TARGET_TYPE_UNSTRUCTURED_MULTICLASS_KEY = "Unstructured (Multiclass)"
-    TARGET_TYPE_UNSTRUCTURED_OTHER_KEY = "Unstructured (Other)"
+    TARGET_TYPE_BINARY = "Binary"
+    TARGET_TYPE_REGRESSION = "Regression"
+    TARGET_TYPE_MULTICLASS = "Multiclass"
+    TARGET_TYPE_ANOMALY_DETECTION = "Anomaly Detection"
+    TARGET_TYPE_UNSTRUCTURED_BINARY = "Unstructured (Binary)"
+    TARGET_TYPE_UNSTRUCTURED_REGRESSION = "Unstructured (Regression)"
+    TARGET_TYPE_UNSTRUCTURED_MULTICLASS = "Unstructured (Multiclass)"
+    TARGET_TYPE_UNSTRUCTURED_OTHER = "Unstructured (Other)"
 
     TARGET_NAME_KEY = "target_name"
 
@@ -282,14 +282,14 @@ class ModelSchema(SharedSchema):
         {
             SharedSchema.MODEL_ID_KEY: And(str, len, Use(Namespace.namespaced)),
             TARGET_TYPE_KEY: Or(
-                TARGET_TYPE_BINARY_KEY,
-                TARGET_TYPE_REGRESSION_KEY,
-                TARGET_TYPE_MULTICLASS_KEY,
-                TARGET_TYPE_ANOMALY_DETECTION_KEY,
-                TARGET_TYPE_UNSTRUCTURED_BINARY_KEY,
-                TARGET_TYPE_UNSTRUCTURED_REGRESSION_KEY,
-                TARGET_TYPE_UNSTRUCTURED_MULTICLASS_KEY,
-                TARGET_TYPE_UNSTRUCTURED_OTHER_KEY,
+                TARGET_TYPE_BINARY,
+                TARGET_TYPE_REGRESSION,
+                TARGET_TYPE_MULTICLASS,
+                TARGET_TYPE_ANOMALY_DETECTION,
+                TARGET_TYPE_UNSTRUCTURED_BINARY,
+                TARGET_TYPE_UNSTRUCTURED_REGRESSION,
+                TARGET_TYPE_UNSTRUCTURED_MULTICLASS,
+                TARGET_TYPE_UNSTRUCTURED_OTHER,
             ),
             SharedSchema.SETTINGS_SECTION_KEY: {
                 NAME_KEY: And(str, len),
@@ -435,8 +435,8 @@ class ModelSchema(SharedSchema):
         """
 
         return metadata[ModelSchema.TARGET_TYPE_KEY] in [
-            cls.TARGET_TYPE_BINARY_KEY,
-            cls.TARGET_TYPE_UNSTRUCTURED_BINARY_KEY,
+            cls.TARGET_TYPE_BINARY,
+            cls.TARGET_TYPE_UNSTRUCTURED_BINARY,
         ]
 
     @classmethod
@@ -456,8 +456,8 @@ class ModelSchema(SharedSchema):
         """
 
         return metadata[ModelSchema.TARGET_TYPE_KEY] in [
-            cls.TARGET_TYPE_REGRESSION_KEY,
-            cls.TARGET_TYPE_UNSTRUCTURED_REGRESSION_KEY,
+            cls.TARGET_TYPE_REGRESSION,
+            cls.TARGET_TYPE_UNSTRUCTURED_REGRESSION,
         ]
 
     @classmethod
@@ -477,8 +477,8 @@ class ModelSchema(SharedSchema):
         """
 
         return metadata[ModelSchema.TARGET_TYPE_KEY] in [
-            cls.TARGET_TYPE_MULTICLASS_KEY,
-            cls.TARGET_TYPE_UNSTRUCTURED_MULTICLASS_KEY,
+            cls.TARGET_TYPE_MULTICLASS,
+            cls.TARGET_TYPE_UNSTRUCTURED_MULTICLASS,
         ]
 
     @classmethod
@@ -498,10 +498,10 @@ class ModelSchema(SharedSchema):
         """
 
         return metadata[ModelSchema.TARGET_TYPE_KEY] in [
-            ModelSchema.TARGET_TYPE_UNSTRUCTURED_REGRESSION_KEY,
-            ModelSchema.TARGET_TYPE_UNSTRUCTURED_BINARY_KEY,
-            ModelSchema.TARGET_TYPE_UNSTRUCTURED_MULTICLASS_KEY,
-            ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER_KEY,
+            ModelSchema.TARGET_TYPE_UNSTRUCTURED_REGRESSION,
+            ModelSchema.TARGET_TYPE_UNSTRUCTURED_BINARY,
+            ModelSchema.TARGET_TYPE_UNSTRUCTURED_MULTICLASS,
+            ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER,
         ]
 
     @classmethod
@@ -662,10 +662,10 @@ class DeploymentSchema(SharedSchema):
     LABEL_KEY = "label"  # Settings, Optional
     DESCRIPTION_KEY = "description"  # Settings, Optional
     IMPORTANCE_KEY = "importance"  # Settings, Optional
-    IMPORTANCE_CRITICAL_VALUE = "CRITICAL"
-    IMPORTANCE_HIGH_VALUE = "HIGH"
-    IMPORTANCE_MODERATE_VALUE = "MODERATE"
-    IMPORTANCE_LOW_VALUE = "LOW"
+    IMPORTANCE_CRITICAL = "CRITICAL"
+    IMPORTANCE_HIGH = "HIGH"
+    IMPORTANCE_MODERATE = "MODERATE"
+    IMPORTANCE_LOW = "LOW"
 
     ENABLE_TARGET_DRIFT_KEY = "enable_target_drift"  # Settings, Optional
     ENABLE_FEATURE_DRIFT_KEY = "enable_feature_drift"  # Settings, Optional
@@ -700,10 +700,7 @@ class DeploymentSchema(SharedSchema):
                 # the user will need to wait for approval from a reviewer in order to be able
                 # to apply new changes and merge them to the main branch.
                 Optional(IMPORTANCE_KEY): Or(  # fromModelPackage
-                    IMPORTANCE_CRITICAL_VALUE,
-                    IMPORTANCE_HIGH_VALUE,
-                    IMPORTANCE_MODERATE_VALUE,
-                    IMPORTANCE_LOW_VALUE,
+                    IMPORTANCE_CRITICAL, IMPORTANCE_HIGH, IMPORTANCE_MODERATE, IMPORTANCE_LOW
                 ),
                 Optional(ASSOCIATION_KEY): {
                     Optional(ASSOCIATION_ASSOCIATION_ID_COLUMN_KEY): And(str, len),

--- a/tests/functional/test_model_training_holdout_data.py
+++ b/tests/functional/test_model_training_holdout_data.py
@@ -308,7 +308,7 @@ class TestModelTrainingHoldoutData:
         with temporarily_replace_schema_value(
             model_metadata_yaml_file,
             ModelSchema.TARGET_TYPE_KEY,
-            new_value=ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER_KEY,
+            new_value=ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER,
         ):
             # 1. Create a model just as a preliminary requirement (use GitHub action)
             printout(
@@ -409,7 +409,7 @@ class TestModelTrainingHoldoutData:
         with temporarily_replace_schema_value(
             model_metadata_yaml_file,
             ModelSchema.TARGET_TYPE_KEY,
-            new_value=ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER_KEY,
+            new_value=ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER,
         ):
             # 1. Create a model just as a preliminary requirement (use GitHub action)
             printout(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -81,7 +81,7 @@ def create_partial_model_schema(is_single=True, num_models=1, with_target_type=F
             ModelSchema.VERSION_KEY: {ModelSchema.MODEL_ENV_ID_KEY: str(ObjectId())},
         }
         if with_target_type:
-            partial_schema[ModelSchema.TARGET_TYPE_KEY] = ModelSchema.TARGET_TYPE_REGRESSION_KEY
+            partial_schema[ModelSchema.TARGET_TYPE_KEY] = ModelSchema.TARGET_TYPE_REGRESSION
         return partial_schema
 
     if is_single:
@@ -218,7 +218,7 @@ def fixture_single_model_factory(workspace_path, common_path_with_code):
 
         single_model_metadata = {
             ModelSchema.MODEL_ID_KEY: Namespace.namespaced(user_provided_id or str(uuid.uuid4())),
-            ModelSchema.TARGET_TYPE_KEY: ModelSchema.TARGET_TYPE_REGRESSION_KEY,
+            ModelSchema.TARGET_TYPE_KEY: ModelSchema.TARGET_TYPE_REGRESSION,
             ModelSchema.SETTINGS_SECTION_KEY: {
                 ModelSchema.NAME_KEY: name,
                 ModelSchema.TARGET_NAME_KEY: "Grade 2014",
@@ -476,7 +476,7 @@ def mock_full_binary_model_schema(mock_full_custom_model_checks):
 
     return {
         ModelSchema.MODEL_ID_KEY: "abc123",
-        ModelSchema.TARGET_TYPE_KEY: ModelSchema.TARGET_TYPE_BINARY_KEY,
+        ModelSchema.TARGET_TYPE_KEY: ModelSchema.TARGET_TYPE_BINARY,
         ModelSchema.SETTINGS_SECTION_KEY: {
             ModelSchema.NAME_KEY: "Awesome Model",
             ModelSchema.DESCRIPTION_KEY: "My awesome model",

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -78,7 +78,7 @@ def fixture_minimal_regression_model_info():
     """A fixture to create a ModelInfo with a minimal regression model information."""
     metadata = {
         ModelSchema.MODEL_ID_KEY: "abc123",
-        ModelSchema.TARGET_TYPE_KEY: ModelSchema.TARGET_TYPE_REGRESSION_KEY,
+        ModelSchema.TARGET_TYPE_KEY: ModelSchema.TARGET_TYPE_REGRESSION,
         ModelSchema.SETTINGS_SECTION_KEY: {
             ModelSchema.NAME_KEY: "minimal-regression-model",
             ModelSchema.TARGET_NAME_KEY: "target_column",
@@ -101,7 +101,7 @@ def fixture_regression_model_info():
 
     metadata = {
         ModelSchema.MODEL_ID_KEY: "abc123",
-        ModelSchema.TARGET_TYPE_KEY: ModelSchema.TARGET_TYPE_REGRESSION_KEY,
+        ModelSchema.TARGET_TYPE_KEY: ModelSchema.TARGET_TYPE_REGRESSION,
         ModelSchema.SETTINGS_SECTION_KEY: {
             ModelSchema.NAME_KEY: "Awesome Model",
             ModelSchema.TARGET_NAME_KEY: "target_column",
@@ -615,10 +615,10 @@ class TestCustomModelTrainingHoldoutPayload:
             if is_unstructured:
                 metadata[
                     ModelSchema.TARGET_TYPE_KEY
-                ] = ModelSchema.TARGET_TYPE_UNSTRUCTURED_REGRESSION_KEY
+                ] = ModelSchema.TARGET_TYPE_UNSTRUCTURED_REGRESSION
                 settings_section[ModelSchema.HOLDOUT_DATASET_ID_KEY] = holdout_dataset_id
             else:
-                metadata[ModelSchema.TARGET_TYPE_KEY] = ModelSchema.TARGET_TYPE_REGRESSION_KEY
+                metadata[ModelSchema.TARGET_TYPE_KEY] = ModelSchema.TARGET_TYPE_REGRESSION
                 settings_section[ModelSchema.PARTITIONING_COLUMN_KEY] = partitioning_column
 
             return ModelInfo(yaml_filepath="/tmp/dummy", model_path="/tmp/model", metadata=metadata)
@@ -1562,8 +1562,8 @@ class TestDeploymentPayloadConstruction:
                 "actual": "Origin description",
             },
             DeploymentSchema.IMPORTANCE_KEY: {
-                "desired": DeploymentSchema.IMPORTANCE_MODERATE_VALUE,
-                "actual": DeploymentSchema.IMPORTANCE_LOW_VALUE,
+                "desired": DeploymentSchema.IMPORTANCE_MODERATE,
+                "actual": DeploymentSchema.IMPORTANCE_LOW,
             },
         }
         deployment = {attr: body["actual"] for attr, body in attr_map.items()}
@@ -1586,7 +1586,7 @@ class TestDeploymentPayloadConstruction:
 
         label_value = "Origin label"
         description_value = "Origin description"
-        importance_value = DeploymentSchema.IMPORTANCE_LOW_VALUE
+        importance_value = DeploymentSchema.IMPORTANCE_LOW
         attr_map = {
             DeploymentSchema.LABEL_KEY: {"desired": label_value, "actual": label_value},
             DeploymentSchema.DESCRIPTION_KEY: {
@@ -1615,8 +1615,8 @@ class TestDeploymentPayloadConstruction:
                 "actual": "Origin description",
             },
             DeploymentSchema.IMPORTANCE_KEY: {
-                "desired": DeploymentSchema.IMPORTANCE_LOW_VALUE,
-                "actual": DeploymentSchema.IMPORTANCE_LOW_VALUE,
+                "desired": DeploymentSchema.IMPORTANCE_LOW,
+                "actual": DeploymentSchema.IMPORTANCE_LOW,
             },
         }
         deployment = {attr: body["actual"] for attr, body in attr_map.items()}
@@ -1640,7 +1640,7 @@ class TestDeploymentPayloadConstruction:
             },
             DeploymentSchema.IMPORTANCE_KEY: {
                 "desired": None,
-                "actual": DeploymentSchema.IMPORTANCE_LOW_VALUE,
+                "actual": DeploymentSchema.IMPORTANCE_LOW,
             },
         }
         deployment = {attr: body["actual"] for attr, body in attr_map.items()}
@@ -1666,7 +1666,7 @@ class TestDeploymentPayloadConstruction:
             },
             DeploymentSchema.IMPORTANCE_KEY: {
                 "desired": empty_importance,
-                "actual": DeploymentSchema.IMPORTANCE_LOW_VALUE,
+                "actual": DeploymentSchema.IMPORTANCE_LOW,
             },
         }
         deployment = {attr: body["actual"] for attr, body in attr_map.items()}

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -56,7 +56,7 @@ class TestModelSchemaValidator:
 
     @pytest.mark.parametrize(
         "binary_target_type",
-        [ModelSchema.TARGET_TYPE_BINARY_KEY, ModelSchema.TARGET_TYPE_UNSTRUCTURED_BINARY_KEY],
+        [ModelSchema.TARGET_TYPE_BINARY, ModelSchema.TARGET_TYPE_UNSTRUCTURED_BINARY],
     )
     @pytest.mark.parametrize("is_single", [True, False], ids=["single", "multi"])
     def test_for_binary_model(self, binary_target_type, is_single):
@@ -108,7 +108,7 @@ class TestModelSchemaValidator:
 
     @pytest.mark.parametrize(
         "binary_target_type",
-        [ModelSchema.TARGET_TYPE_BINARY_KEY, ModelSchema.TARGET_TYPE_UNSTRUCTURED_BINARY_KEY],
+        [ModelSchema.TARGET_TYPE_BINARY, ModelSchema.TARGET_TYPE_UNSTRUCTURED_BINARY],
     )
     @pytest.mark.parametrize(
         "class_label_key",
@@ -129,8 +129,8 @@ class TestModelSchemaValidator:
     @pytest.mark.parametrize(
         "regression_target_type",
         [
-            ModelSchema.TARGET_TYPE_REGRESSION_KEY,
-            ModelSchema.TARGET_TYPE_UNSTRUCTURED_REGRESSION_KEY,
+            ModelSchema.TARGET_TYPE_REGRESSION,
+            ModelSchema.TARGET_TYPE_UNSTRUCTURED_REGRESSION,
         ],
     )
     @pytest.mark.parametrize("is_single", [True, False], ids=["single", "multi"])
@@ -145,8 +145,8 @@ class TestModelSchemaValidator:
     @pytest.mark.parametrize(
         "multiclass_target_type",
         [
-            ModelSchema.TARGET_TYPE_MULTICLASS_KEY,
-            ModelSchema.TARGET_TYPE_UNSTRUCTURED_MULTICLASS_KEY,
+            ModelSchema.TARGET_TYPE_MULTICLASS,
+            ModelSchema.TARGET_TYPE_UNSTRUCTURED_MULTICLASS,
         ],
     )
     @pytest.mark.parametrize("is_single", [True, False], ids=["single", "multi"])
@@ -164,7 +164,7 @@ class TestModelSchemaValidator:
         """A case to test a missing key in a Multi-Class model schema."""
 
         def _set_multiclass_keys(schema):
-            schema[ModelSchema.TARGET_TYPE_KEY] = ModelSchema.TARGET_TYPE_MULTICLASS_KEY
+            schema[ModelSchema.TARGET_TYPE_KEY] = ModelSchema.TARGET_TYPE_MULTICLASS
 
         with pytest.raises(InvalidModelSchema):
             self._validate_for_model_type(is_single, _set_multiclass_keys)
@@ -174,7 +174,7 @@ class TestModelSchemaValidator:
         """A case to test an unstructured model schema."""
 
         def _set_unstructured_keys(schema):
-            schema[ModelSchema.TARGET_TYPE_KEY] = ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER_KEY
+            schema[ModelSchema.TARGET_TYPE_KEY] = ModelSchema.TARGET_TYPE_UNSTRUCTURED_OTHER
 
         self._validate_for_model_type(is_single, _set_unstructured_keys)
 
@@ -185,24 +185,24 @@ class TestModelSchemaValidator:
         Key = namedtuple("Key", ["type", "name", "value"])
         mutual_exclusive_keys = {
             Key(
-                type=ModelSchema.TARGET_TYPE_REGRESSION_KEY,
+                type=ModelSchema.TARGET_TYPE_REGRESSION,
                 name=ModelSchema.PREDICTION_THRESHOLD_KEY,
                 value=0.5,
             ),
             (
                 Key(
-                    type=ModelSchema.TARGET_TYPE_BINARY_KEY,
+                    type=ModelSchema.TARGET_TYPE_BINARY,
                     name=ModelSchema.POSITIVE_CLASS_LABEL_KEY,
                     value="1",
                 ),
                 Key(
-                    type=ModelSchema.TARGET_TYPE_BINARY_KEY,
+                    type=ModelSchema.TARGET_TYPE_BINARY,
                     name=ModelSchema.NEGATIVE_CLASS_LABEL_KEY,
                     value="0",
                 ),
             ),
             Key(
-                type=ModelSchema.TARGET_TYPE_MULTICLASS_KEY,
+                type=ModelSchema.TARGET_TYPE_MULTICLASS,
                 name=ModelSchema.CLASS_LABELS_KEY,
                 value=("a", "b", "c"),
             ),


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
The idea is that only attribute names will have the _KEY suffix in their constant names. Value definition will only start with the related attribute name.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Renaming only

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
