### PR TITLE
[RAPTOR-9580] Enable training/holdout assignment at model version level

### DIFF
--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -322,9 +322,9 @@ class ModelSchema(SharedSchema):
                 Optional(EGRESS_NETWORK_POLICY_KEY): Or(
                     EGRESS_NETWORK_POLICY_NONE, EGRESS_NETWORK_POLICY_PUBLIC
                 ),
-                # Optional(PARTITIONING_COLUMN_KEY): And(str, len),
-                # Optional(TRAINING_DATASET_ID_KEY): And(str, ObjectId.is_valid),
-                # Optional(HOLDOUT_DATASET_ID_KEY): And(str, ObjectId.is_valid),
+                Optional(PARTITIONING_COLUMN_KEY): And(str, len),
+                Optional(TRAINING_DATASET_ID_KEY): And(str, ObjectId.is_valid),
+                Optional(HOLDOUT_DATASET_ID_KEY): And(str, ObjectId.is_valid),
                 Optional(MODEL_REPLACEMENT_REASON_KEY, default=MODEL_REPLACEMENT_REASON_OTHER): Or(
                     MODEL_REPLACEMENT_REASON_ACCURACY,
                     MODEL_REPLACEMENT_REASON_DATA_DRIFT,

--- a/tests/functional/test_deployment_github_actions.py
+++ b/tests/functional/test_deployment_github_actions.py
@@ -491,7 +491,7 @@ class TestDeploymentGitHubActions:
         """An end-to-end case to test changes in deployment settings."""
 
         with temporarily_upload_training_dataset_for_structured_model(
-            dr_client, model_metadata_yaml_file, is_model_level=True, event_name=event_name
+            dr_client, model_metadata_yaml_file, is_model_level=False, event_name=event_name
         ):
             try:
                 # Run the GitHub action to create a model and deployment

--- a/tests/functional/test_model_training_holdout_data.py
+++ b/tests/functional/test_model_training_holdout_data.py
@@ -129,7 +129,6 @@ class TestModelTrainingHoldoutData:
         versions = dr_client.fetch_custom_model_versions(custom_model["id"])
         assert len(versions) == 1
 
-    @pytest.mark.skip(reason="Training/holdout data is not supported at version level, just yet.")
     def test_e2e_set_training_and_holdout_datasets_for_structured_model_version(
         self,
         dr_client,
@@ -391,7 +390,6 @@ class TestModelTrainingHoldoutData:
         ) as holdout_dataset_id:
             yield training_dataset_id, holdout_dataset_id
 
-    @pytest.mark.skip(reason="Training/holdout data is not supported at version level, just yet.")
     def test_e2e_set_training_and_holdout_datasets_for_unstructured_model_version(
         self,
         dr_client,

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -237,9 +237,6 @@ class TestModelSchemaValidator:
         attributes.
         """
 
-        if section == ModelSchema.VERSION_KEY:
-            pytest.skip("Training/holdout data are still not supported at version level.")
-
         model_metadata = create_partial_model_schema(is_single, num_models=1, with_target_type=True)
 
         edit_metadata = (
@@ -256,7 +253,6 @@ class TestModelSchemaValidator:
             else:
                 ModelSchema.validate_and_transform_multi(model_metadata)
 
-    @pytest.mark.skip(reason="Training/holdout data is currently not supported at version level.")
     @pytest.mark.parametrize("is_single", [True, False], ids=["single", "multi"])
     @pytest.mark.parametrize("is_unstructured", [True, False], ids=["unstructured", "structured"])
     @pytest.mark.parametrize("with_holdout", [True, False], ids=["with-holdout", "without-holdout"])


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
With the functionality being a GA, to enable users to assign training/holdout datasets at model version level it is required to add this support to the GH action.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Uncomment related fields in the model's schema
* Functional test
* Unit test

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)
