### PR TITLE
[RAPTOR-9589] Fix local variable 'training_holdout_updated' referenced before assignment

### DIFF
--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -773,6 +773,7 @@ class ModelController(ControllerBase):
             )
             is not None
         )
+        training_holdout_updated = False
         if not datarobot_custom_model.get("isTrainingDataForVersionsPermanentlyEnabled", False):
             # NOTE: training/holdout datasets update should always come after model's setting update
             training_holdout_updated = (


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
During an execution of the functional test `TestDeploymentGitHubActions.test_e2e_deployment_settings[push]` it was detected that a variable is being used before assignment.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Initialize the related local variable

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run a certain specifi functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<test-to-run>`. The workflow will extract whatever test(s) specified
after the assignment sign and will trigger an action to run it. The execution can be viewed under
the `Actions` tab.
