### PR TITLE
Implicitly set a deployment's default importance value to LOW

### DIFF
--- a/src/deployment_controller.py
+++ b/src/deployment_controller.py
@@ -219,6 +219,11 @@ class DeploymentController(ControllerBase):
                     updated = True
 
                 if updated:
+                    logger.info(
+                        "Deployment settings were updated, git_id: %s, deployment_id: %s.",
+                        deployment_info.user_provided_id,
+                        datarobot_deployment.deployment["id"],
+                    )
                     self.metrics.total_affected.value += 1
 
     def _create_deployment(self, deployment_info):
@@ -242,7 +247,7 @@ class DeploymentController(ControllerBase):
         deployment, _ = self._dr_client.update_deployment_settings(deployment, deployment_info)
 
         logger.info(
-            "A new deployment was created, git_id: %s, id: %s.",
+            "A new deployment was created, git_id: %s, deployment_id: %s.",
             deployment_info.user_provided_id,
             deployment["id"],
         )

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -707,7 +707,7 @@ class DeploymentSchema(SharedSchema):
                 # operation, such as 'create', 'update', 'delete', etc. So, practically
                 # the user will need to wait for approval from a reviewer in order to be able
                 # to apply new changes and merge them to the main branch.
-                Optional(IMPORTANCE_KEY): Or(  # fromModelPackage
+                Optional(IMPORTANCE_KEY, default=IMPORTANCE_LOW): Or(  # fromModelPackage
                     IMPORTANCE_CRITICAL, IMPORTANCE_HIGH, IMPORTANCE_MODERATE, IMPORTANCE_LOW
                 ),
                 Optional(ASSOCIATION_KEY): {

--- a/tests/functional/test_deployment_github_actions.py
+++ b/tests/functional/test_deployment_github_actions.py
@@ -572,14 +572,9 @@ class TestDeploymentGitHubActions:
         deployment_attrs = [
             (DeploymentSchema.LABEL_KEY, "label"),
             (DeploymentSchema.DESCRIPTION_KEY, "description"),
-            (DeploymentSchema.IMPORTANCE_KEY, "importance"),
         ]
         for schema_attr, dr_attr in deployment_attrs:
-            old_value = origin_deployment[dr_attr]
-            if schema_attr == DeploymentSchema.IMPORTANCE_KEY:
-                new_value = "HIGH" if old_value == "LOW" else "LOW"
-            else:
-                new_value = f"{old_value} - NEW"
+            new_value = f"{origin_deployment[dr_attr]} - NEW"
             deployment_info.set_settings_value(schema_attr, value=new_value)
 
         with temporarily_replace_schema(deployment_metadata_yaml_file, deployment_info.metadata):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->
Although the default in DR for a deployment's importance is LOW, in order to make sure that user's will work without requiring approvals unless specified otherwise, the default is explicitly set to LOW.

## CHANGES
<!-- List the changes in this PR, in highlights. -->
* Set the default importance attribute value in a deployment's settings schema to LOW
* Fix a functional test to not try and change the importance to HIGH, because it results in a test failure due to the need for approval.


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run a certain specifi functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<test-to-run>`. The workflow will extract whatever test(s) specified
after the assignment sign and will trigger an action to run it. The execution can be viewed under
the `Actions` tab.
