### PR TITLE
[MMM-14420] Fix broken test: test_e2e_pull_request_event_with_multiple_changes

### DIFF
--- a/tests/functional/test_deployment_github_actions.py
+++ b/tests/functional/test_deployment_github_actions.py
@@ -791,7 +791,7 @@ class TestDeploymentGitHubActions:
 
             printout(str(exec_info.value))
             assert any(record.levelname in ("WARNING", "ERROR") for record in caplog.records)
-            assert "WARNING" in str(exec_info.value) or "WARNING" in str(exec_info.value)
+            assert "WARNING" in str(exec_info.value) or "ERROR" in str(exec_info.value)
         printout("Done")
 
     @contextlib.contextmanager

--- a/tests/models/py3_sklearn/custom.py
+++ b/tests/models/py3_sklearn/custom.py
@@ -26,9 +26,9 @@ def transform(data, model):
     pd.DataFrame
     """
     # Execute any steps you need to do before scoring
-    # Remove target columns if they're in the dataset
-    for target_col in ["Grade 2014", "Species"]:
-        if target_col in data:
-            data.pop(target_col)
+    # Remove target and id columns if they're in the dataset
+    for unused_column in ["Grade 2014", "Species", "id"]:
+        if unused_column in data:
+            data.pop(unused_column)
     data = data.fillna(0)
     return data


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
The functional test `tests/functional/test_model_github_actions.py::TestModelGitHubActions::test_e2e_pull_request_event_with_multiple_changes` fails with:
```
ERROR    root:main.py:116 Custom model version check failed. model_id: 650c018c004ba77cfd095083, model_version_id: 650c01bf8dfc0831d7448d7d, check: errorCheck, status: failed, 
message: ERROR: Failure when making predictions: Number of features of the model must match the input. 
Model n_features is 33 and input n_features is 34 .
``` 
<!-- For efficient review please explain "why" you are making this change. -->


## CHANGES
* Remove `id` column during `transform` to end up with the number of features that the model expects.
<!-- List the changes in this PR, in highlights. -->


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [x] Run all functional tests (>50 minutes)



**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
