### PR TITLE
[MMM-14420] Add Registered model support

### DIFF
--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -629,6 +629,11 @@ class ModelController(ControllerBase):
                     custom_model["id"], latest_version["id"], model_info
                 )
 
+            if model_info.should_register_model:
+                self._dr_client.create_or_update_registered_model(
+                    latest_version["id"], model_info.registered_model_name
+                )
+
     @staticmethod
     def _was_new_version_created(previous_latest_version, latest_version):
         return not previous_latest_version or latest_version["id"] != previous_latest_version["id"]

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -356,6 +356,14 @@ class ModelInfo(InfoBase):
         return False
 
     @property
+    def should_register_model(self):
+        return self.registered_model_name is not None
+
+    @property
+    def registered_model_name(self):
+        return self.get_value(ModelSchema.MODEL_REGISTRY_KEY, ModelSchema.MODEL_NAME)
+
+    @property
     def should_run_test(self):
         """
         Querying the model's metadata and check whether a custom model testing should be executed.

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -357,10 +357,12 @@ class ModelInfo(InfoBase):
 
     @property
     def should_register_model(self):
+        """Wheter this model should be added as a registered model."""
         return self.registered_model_name is not None
 
     @property
     def registered_model_name(self):
+        """The registered model name to use or None if model should not be registered."""
         return self.get_value(ModelSchema.MODEL_REGISTRY_KEY, ModelSchema.MODEL_NAME)
 
     @property

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -282,6 +282,9 @@ class ModelSchema(SharedSchema):
     MINIMUM_PAYLOAD_SIZE_KEY = "minimum_payload_size"
     MAXIMUM_PAYLOAD_SIZE_KEY = "maximum_payload_size"
 
+    MODEL_REGISTRY_KEY = "model_registry"
+    MODEL_NAME = "model_name"
+
     MODEL_SCHEMA = Schema(
         {
             SharedSchema.MODEL_ID_KEY: And(str, len, Use(Namespace.namespaced)),
@@ -375,6 +378,9 @@ class ModelSchema(SharedSchema):
                         Optional(MAXIMUM_PAYLOAD_SIZE_KEY): And(int, lambda v: v >= 1),
                     },
                 },
+            },
+            Optional(MODEL_REGISTRY_KEY): {
+                Optional(MODEL_NAME): And(str, len),
             },
         }
     )

--- a/tests/functional/test_model_github_actions.py
+++ b/tests/functional/test_model_github_actions.py
@@ -89,6 +89,7 @@ class TestModelGitHubActions:
             self._rename_model,
             self._add_file_check,
             self._remove_file_check,
+            self._add_registered_model,
         ]
         self._run_checks(
             checks,
@@ -332,6 +333,22 @@ class TestModelGitHubActions:
         cm_version_files = [item["filePath"] for item in cm_version["items"]]
         for filepath in files_to_add_and_remove:
             assert (filepath.name in cm_version_files) == is_add
+
+    @classmethod
+    @contextlib.contextmanager
+    def _add_registered_model(cls, git_repo, dr_client, model_metadata, model_metadata_yaml_file):
+        printout("Create new registered model ...")
+        model_metadata.update(
+            {ModelSchema.MODEL_REGISTRY_KEY: {ModelSchema.MODEL_NAME: "registered_model"}}
+        )
+
+        save_new_metadata_and_commit(
+            model_metadata, model_metadata_yaml_file, git_repo, "Add registered model"
+        )
+
+        yield cls.ExpectedChange(settings_updated=False, version_created=False)
+
+        assert dr_client.get_registered_model_by_name("registered_model") is not None
 
     @staticmethod
     def _merge_changes_into_the_main_branch(git_repo, merge_branch):

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -22,6 +22,7 @@ import schema
 from bson import ObjectId
 from mock import Mock
 from mock import patch
+from responses import matchers
 
 from common.exceptions import DataRobotClientError
 from common.http_requester import HttpRequester
@@ -43,6 +44,14 @@ def fixture_webserver():
     """A fixture to return a fake DataRobot webserver."""
 
     return "http://www.datarobot.dummy-app"
+
+
+@pytest.fixture(name="url_factory")
+def fixture_url_factory(webserver):
+    def _inner(route):
+        return f"{webserver}/api/v2/{route}"
+
+    return _inner
 
 
 @pytest.fixture(name="api_token")
@@ -126,7 +135,7 @@ def fixture_regression_model_info():
 
 
 def mock_paginated_responses(
-    total_num_entities, num_entities_in_page, url_factory, entity_response_factory_fn
+    total_num_entities, num_entities_in_page, url_factory, entity_response_factory_fn, match=None
 ):
     """A method to mock paginated responses from DataRobot."""
 
@@ -144,6 +153,7 @@ def mock_paginated_responses(
                 "data": entities_in_page,
             },
             status=200,
+            match=match or [],
         )
         return entities_in_page
 
@@ -160,6 +170,20 @@ def mock_paginated_responses(
                 quotient, remainder, has_next=False
             )
     return total_entities
+
+
+def mock_single_page_response(url, entities, match=None):
+    def url_factory(_):
+        return url
+
+    entities_iter = iter(entities)
+
+    def entity_response_factory_fn(_):
+        return next(entities_iter)
+
+    return mock_paginated_responses(
+        len(entities), max(len(entities), 1), url_factory, entity_response_factory_fn, match
+    )
 
 
 class TestPaginator:
@@ -1476,6 +1500,102 @@ class TestCustomModelVersionDependencies:
         assert response_obj.call_count == 1
         for response_obj in response_objs:
             assert response_obj.call_count == 1
+
+
+class TestRegisteredModels:
+    @pytest.fixture
+    def registered_model_response_mock(self, url_factory):
+        with responses.RequestsMock():
+            registered_model = {
+                "id": "existing_registered_model_id",
+                "name": "existing_registered_model",
+            }
+
+            params = {"search": registered_model["name"]}
+            mock_single_page_response(
+                url_factory(DrClient.REGISTERED_MODELS_LIST_ROUTE),
+                entities=[registered_model],
+                match=[matchers.query_param_matcher(params)],
+            )
+
+            yield registered_model
+
+    @responses.activate
+    def test_create_new_registered_model(self, dr_client, url_factory):
+        params = {"search": "non_existent_registered_model"}
+        mock_single_page_response(
+            url_factory(DrClient.REGISTERED_MODELS_LIST_ROUTE),
+            entities=[],
+            match=[matchers.query_param_matcher(params)],
+        )
+
+        responses.post(
+            url=url_factory(DrClient.MODEL_PACKAGES_CREATE_ROUTE),
+            json={"id": "new_registered_model_id"},
+            status=201,
+        )
+
+        registered_model_version = dr_client.create_or_update_registered_model(
+            "custom_model_version_id", "non_existent_registered_model"
+        )
+
+        assert registered_model_version == "new_registered_model_id"
+
+    @responses.activate
+    def test_update_existing_registered_model(
+        self, dr_client, url_factory, custom_model_version_id, registered_model_response_mock
+    ):
+
+        mock_single_page_response(
+            url_factory(
+                DrClient.REGISTERED_MODELS_VERSIONS_ROUTE.format(
+                    registered_model_id=registered_model_response_mock["id"]
+                )
+            ),
+            entities=[],
+        )
+
+        create_model_package_payload = {
+            "customModelVersionId": custom_model_version_id,
+            "registeredModelId": registered_model_response_mock["id"],
+        }
+        new_registered_model_id = "new_registered_model_id"
+        responses.post(
+            url=url_factory(DrClient.MODEL_PACKAGES_CREATE_ROUTE),
+            match=[matchers.json_params_matcher(create_model_package_payload)],
+            json={"id": new_registered_model_id},
+            status=201,
+        )
+        registered_model_version = dr_client.create_or_update_registered_model(
+            custom_model_version_id, registered_model_response_mock["name"]
+        )
+
+        assert registered_model_version == new_registered_model_id
+
+    @responses.activate
+    def test_version_already_registered(
+        self, dr_client, url_factory, custom_model_version_id, registered_model_response_mock
+    ):
+        registered_model_version_id = "registered_model_version_id"
+        mock_single_page_response(
+            url_factory(
+                DrClient.REGISTERED_MODELS_VERSIONS_ROUTE.format(
+                    registered_model_id=registered_model_response_mock["id"]
+                )
+            ),
+            entities=[
+                {
+                    "id": registered_model_version_id,
+                    "modelId": custom_model_version_id,
+                }
+            ],
+        )
+
+        registered_model_version = dr_client.create_or_update_registered_model(
+            custom_model_version_id, registered_model_response_mock["name"]
+        )
+
+        assert registered_model_version == registered_model_version_id
 
 
 class TestDeploymentRoutes(SharedRouteTests):

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -48,6 +48,8 @@ def fixture_webserver():
 
 @pytest.fixture(name="url_factory")
 def fixture_url_factory(webserver):
+    """A fixture to create request urls."""
+
     def _inner(route):
         return f"{webserver}/api/v2/{route}"
 
@@ -173,6 +175,8 @@ def mock_paginated_responses(
 
 
 def mock_single_page_response(url, entities, match=None):
+    """Mock single page paginated response."""
+
     def url_factory(_):
         return url
 
@@ -1503,8 +1507,11 @@ class TestCustomModelVersionDependencies:
 
 
 class TestRegisteredModels:
+    """Registered models tests."""
+
     @pytest.fixture
     def registered_model_response_mock(self, url_factory):
+        """Return existing registered model"""
         with responses.RequestsMock():
             registered_model = {
                 "id": "existing_registered_model_id",
@@ -1522,6 +1529,7 @@ class TestRegisteredModels:
 
     @responses.activate
     def test_create_new_registered_model(self, dr_client, url_factory):
+        """Test creating new registered model"""
         params = {"search": "non_existent_registered_model"}
         mock_single_page_response(
             url_factory(DrClient.REGISTERED_MODELS_LIST_ROUTE),
@@ -1545,6 +1553,7 @@ class TestRegisteredModels:
     def test_update_existing_registered_model(
         self, dr_client, url_factory, custom_model_version_id, registered_model_response_mock
     ):
+        """Update existing registered model by creating new version."""
 
         mock_single_page_response(
             url_factory(
@@ -1576,6 +1585,7 @@ class TestRegisteredModels:
     def test_version_already_registered(
         self, dr_client, url_factory, custom_model_version_id, registered_model_response_mock
     ):
+        """Existing registered model that already contains this version should do nothing."""
         registered_model_version_id = "registered_model_version_id"
         mock_single_page_response(
             url_factory(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
As part of the process to support Public Models in DataRobot, we want to make it possible to automatically build and deploy public models. 
<!-- For efficient review please explain "why" you are making this change. -->


## CHANGES
In the model yaml, add support for registering custom model versions using:
```
model_registry:
    model_name: [DataRobot] Awesome Public Model
```

This should create a new registered model called [DataRobot] Awesome Public Model if it does not exist. If it already exists, a new registered model version should be added if it is not already present.
<!-- List the changes in this PR, in highlights. -->


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
