### PR TITLE
[MMM-14942] Support toggling registered model global flag

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -472,7 +472,8 @@ class DrClient:
         str,
             Registered model version id of existing or newly created version.
         """
-        registered_model_id = self.get_registered_model_by_name(registered_model_name)
+        registered_model = self.get_registered_model_by_name(registered_model_name)
+        registered_model_id = registered_model["id"] if registered_model else None
         if registered_model_id:
             existing_registered_versions = self._get_registered_model_versions(registered_model_id)
             existing_version_id = next(
@@ -508,14 +509,14 @@ class DrClient:
 
         Returns
         -------
-        str or None,
-            Registered model id if found, otherwise None.
+        dict or None,
+            Registered model if found, otherwise None.
         """
         items = self._paginated_fetch(
             self.REGISTERED_MODELS_LIST_ROUTE,
             params={"search": registered_model_name},
         )
-        return next((item["id"] for item in items if item["name"] == registered_model_name), None)
+        return next((item for item in items if item["name"] == registered_model_name), None)
 
     def _get_registered_model_versions(self, registered_model_id):
         return self._paginated_fetch(

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -501,17 +501,17 @@ class DrClient:
 
         return model_package["id"]
 
-    def set_registered_model_public(self, registered_model_name, is_public):
+    def set_registered_model_global(self, registered_model_name, is_global):
         """
-        Set the public property for a registered model.
+        Set the global property for a registered model.
         This is also known as the global property
 
         Parameters
         ----------
         registered_model_name : str
             Name of registered model.
-        is_public : bool
-            True if model should be public, False if not.
+        is_global : bool
+            True if model should be global, False if not.
         """
         registered_model = self.get_registered_model_by_name(registered_model_name)
         if not registered_model:
@@ -519,18 +519,30 @@ class DrClient:
                 f"Failed to find registered model by name: {registered_model_name}"
             )
 
+        if registered_model.get("isGlobal", None) == is_global:
+            logger.info(
+                "Registered model '%s' global flag is already: %s", registered_model_name, is_global
+            )
+            return
+
         response = self._http_requester.patch(
             self.REGISTERED_MODEL_ROUTE.format(registered_model_id=registered_model["id"]),
-            json={"isPublic": is_public},
+            json={"isGlobal": is_global},
         )
         if response.status_code != 200:
             raise DataRobotClientError(
-                "Failed to set registered public property "
+                "Failed to set registered global property "
                 f"Registered model name: {registered_model_name}, "
                 f"Response status: {response.status_code}, "
                 f"Response body: {response.text}",
                 code=response.status_code,
             )
+
+        logger.info(
+            "Registered model '%s' global flag has been set to: %s",
+            registered_model_name,
+            is_global,
+        )
 
     def get_registered_model_by_name(self, registered_model_name):
         """

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -502,6 +502,17 @@ class DrClient:
         return model_package["id"]
 
     def set_registered_model_public(self, registered_model_name, is_public):
+        """
+        Set the public property for a registered model.
+        This is also known as the global property
+
+        Parameters
+        ----------
+        registered_model_name : str
+            Name of registered model.
+        is_public : bool
+            True if model should be public, False if not.
+        """
         registered_model = self.get_registered_model_by_name(registered_model_name)
         if not registered_model:
             raise DataRobotClientError(

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -633,7 +633,7 @@ class ModelController(ControllerBase):
                 self._dr_client.create_or_update_registered_model(
                     latest_version["id"], model_info.registered_model_name
                 )
-                self._dr_client.set_registered_model_public(
+                self._dr_client.set_registered_model_global(
                     model_info.registered_model_name, model_info.registered_model_global
                 )
 

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -633,6 +633,9 @@ class ModelController(ControllerBase):
                 self._dr_client.create_or_update_registered_model(
                     latest_version["id"], model_info.registered_model_name
                 )
+                self._dr_client.set_registered_model_public(
+                    model_info.registered_model_name, model_info.registered_model_global
+                )
 
     @staticmethod
     def _was_new_version_created(previous_latest_version, latest_version):

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -366,6 +366,11 @@ class ModelInfo(InfoBase):
         return self.get_value(ModelSchema.MODEL_REGISTRY_KEY, ModelSchema.MODEL_NAME)
 
     @property
+    def registered_model_global(self):
+        """Wheter the registered model should be global or not."""
+        return self.get_value(ModelSchema.MODEL_REGISTRY_KEY, ModelSchema.GLOBAL)
+
+    @property
     def should_run_test(self):
         """
         Querying the model's metadata and check whether a custom model testing should be executed.

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -24,6 +24,7 @@ from schema_validator import SharedSchema
 logger = logging.getLogger()
 
 
+# pylint: disable=too-many-public-methods
 class InfoBase(ABC):
     """An abstract base class for models and deployments information classes."""
 

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -284,6 +284,7 @@ class ModelSchema(SharedSchema):
 
     MODEL_REGISTRY_KEY = "model_registry"
     MODEL_NAME = "model_name"
+    GLOBAL = "global"
 
     MODEL_SCHEMA = Schema(
         {
@@ -381,6 +382,7 @@ class ModelSchema(SharedSchema):
             },
             Optional(MODEL_REGISTRY_KEY): {
                 Optional(MODEL_NAME): And(str, len),
+                Optional(GLOBAL, default=False): bool,
             },
         }
     )

--- a/tests/functional/test_model_github_actions.py
+++ b/tests/functional/test_model_github_actions.py
@@ -339,7 +339,12 @@ class TestModelGitHubActions:
     def _add_registered_model(cls, git_repo, dr_client, model_metadata, model_metadata_yaml_file):
         printout("Create new registered model ...")
         model_metadata.update(
-            {ModelSchema.MODEL_REGISTRY_KEY: {ModelSchema.MODEL_NAME: "registered_model"}}
+            {
+                ModelSchema.MODEL_REGISTRY_KEY: {
+                    ModelSchema.MODEL_NAME: "registered_model",
+                    ModelSchema.GLOBAL: True,
+                }
+            }
         )
 
         save_new_metadata_and_commit(
@@ -348,7 +353,8 @@ class TestModelGitHubActions:
 
         yield cls.ExpectedChange(settings_updated=False, version_created=False)
 
-        assert dr_client.get_registered_model_by_name("registered_model") is not None
+        registered_model = dr_client.get_registered_model_by_name("registered_model")
+        assert registered_model["isPublic"]
 
     @staticmethod
     def _merge_changes_into_the_main_branch(git_repo, merge_branch):

--- a/tests/functional/test_model_github_actions.py
+++ b/tests/functional/test_model_github_actions.py
@@ -339,12 +339,7 @@ class TestModelGitHubActions:
     def _add_registered_model(cls, git_repo, dr_client, model_metadata, model_metadata_yaml_file):
         printout("Create new registered model ...")
         model_metadata.update(
-            {
-                ModelSchema.MODEL_REGISTRY_KEY: {
-                    ModelSchema.MODEL_NAME: "registered_model",
-                    ModelSchema.GLOBAL: True,
-                }
-            }
+            {ModelSchema.MODEL_REGISTRY_KEY: {ModelSchema.MODEL_NAME: "registered_model"}}
         )
 
         save_new_metadata_and_commit(
@@ -353,8 +348,7 @@ class TestModelGitHubActions:
 
         yield cls.ExpectedChange(settings_updated=False, version_created=False)
 
-        registered_model = dr_client.get_registered_model_by_name("registered_model")
-        assert registered_model["isPublic"]
+        assert dr_client.get_registered_model_by_name("registered_model") is not None
 
     @staticmethod
     def _merge_changes_into_the_main_branch(git_repo, merge_branch):

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -445,7 +445,7 @@ class TestCustomModelRoutes(SharedRouteTests):
         )
         expected_model = expected_model[0][0]
         delete_url = f"{custom_models_url}{expected_model['id']}/"
-        responses.add(responses.DELETE, delete_url, json={}, status=204)
+        responses.add(responses.DELETE, delete_url, status=204)
         dr_client.delete_custom_model_by_user_provided_id(expected_model["userProvidedId"])
 
     @responses.activate

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -1605,11 +1605,16 @@ class TestRegisteredModels:
 
         assert registered_model_version == registered_model_version_id
 
+    @pytest.mark.parametrize("is_already_global", [True, False])
     @responses.activate
-    def test_set_public(self, dr_client, paginated_url_factory):
-        """Test setting registered model as public"""
+    def test_set_global(self, dr_client, paginated_url_factory, is_already_global):
+        """Test setting registered model as global"""
 
-        registered_model = {"id": "registered_model_id", "name": "registered_model_name"}
+        registered_model = {
+            "id": "registered_model_id",
+            "name": "registered_model_name",
+            "isGlobal": is_already_global,
+        }
 
         params = {"search": registered_model["name"]}
         mock_single_page_response(
@@ -1618,17 +1623,19 @@ class TestRegisteredModels:
             match=[matchers.query_param_matcher(params)],
         )
 
-        responses.patch(
+        patch_mock = responses.patch(
             url=paginated_url_factory(
                 DrClient.REGISTERED_MODEL_ROUTE.format(registered_model_id=registered_model["id"])
             ),
             status=200,
         )
 
-        dr_client.set_registered_model_public(registered_model["name"], True)
+        dr_client.set_registered_model_global(registered_model["name"], True)
+
+        assert patch_mock.call_count == 0 if is_already_global else 1
 
     @responses.activate
-    def test_set_public_non_existent(self, dr_client, paginated_url_factory):
+    def test_set_global_non_existent(self, dr_client, paginated_url_factory):
         """Test that non existent registered model raises error"""
 
         mock_single_page_response(
@@ -1637,11 +1644,11 @@ class TestRegisteredModels:
         )
 
         with pytest.raises(DataRobotClientError):
-            dr_client.set_registered_model_public("non_existent_registered_model", True)
+            dr_client.set_registered_model_global("non_existent_registered_model", True)
 
     @responses.activate
-    def test_set_public_error(self, dr_client, paginated_url_factory):
-        """Test setting public fails"""
+    def test_set_global_error(self, dr_client, paginated_url_factory):
+        """Test setting global fails"""
 
         registered_model = {"id": "registered_model_id", "name": "registered_model_name"}
 
@@ -1660,7 +1667,7 @@ class TestRegisteredModels:
         )
 
         with pytest.raises(DataRobotClientError):
-            dr_client.set_registered_model_public(registered_model["name"], True)
+            dr_client.set_registered_model_global(registered_model["name"], True)
 
 
 class TestDeploymentRoutes(SharedRouteTests):

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -1605,6 +1605,63 @@ class TestRegisteredModels:
 
         assert registered_model_version == registered_model_version_id
 
+    @responses.activate
+    def test_set_public(self, dr_client, paginated_url_factory):
+        """Test setting registered model as public"""
+
+        registered_model = {"id": "registered_model_id", "name": "registered_model_name"}
+
+        params = {"search": registered_model["name"]}
+        mock_single_page_response(
+            paginated_url_factory(DrClient.REGISTERED_MODELS_LIST_ROUTE),
+            entities=[registered_model],
+            match=[matchers.query_param_matcher(params)],
+        )
+
+        responses.patch(
+            url=paginated_url_factory(
+                DrClient.REGISTERED_MODEL_ROUTE.format(registered_model_id=registered_model["id"])
+            ),
+            status=200,
+        )
+
+        dr_client.set_registered_model_public(registered_model["name"], True)
+
+    @responses.activate
+    def test_set_public_non_existent(self, dr_client, paginated_url_factory):
+        """Test that non existent registered model raises error"""
+
+        mock_single_page_response(
+            paginated_url_factory(DrClient.REGISTERED_MODELS_LIST_ROUTE),
+            entities=[],
+        )
+
+        with pytest.raises(DataRobotClientError):
+            dr_client.set_registered_model_public("non_existent_registered_model", True)
+
+    @responses.activate
+    def test_set_public_error(self, dr_client, paginated_url_factory):
+        """Test setting public fails"""
+
+        registered_model = {"id": "registered_model_id", "name": "registered_model_name"}
+
+        params = {"search": registered_model["name"]}
+        mock_single_page_response(
+            paginated_url_factory(DrClient.REGISTERED_MODELS_LIST_ROUTE),
+            entities=[registered_model],
+            match=[matchers.query_param_matcher(params)],
+        )
+
+        responses.patch(
+            url=paginated_url_factory(
+                DrClient.REGISTERED_MODEL_ROUTE.format(registered_model_id=registered_model["id"])
+            ),
+            status=500,
+        )
+
+        with pytest.raises(DataRobotClientError):
+            dr_client.set_registered_model_public(registered_model["name"], True)
+
 
 class TestDeploymentRoutes(SharedRouteTests):
     """Contains unit-tests to test the DataRobot deployment routes."""


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
For the global models project, we want to support making registered models global.
<!-- For efficient review please explain "why" you are making this change. -->


## CHANGES
*  Add `global` boolean value to `model_registry` in the schema.
* Update `global` flag in model controller.
<!-- List the changes in this PR, in highlights. -->


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
