### PR TITLE
[MMM-14942] Support updating registered model description

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -455,7 +455,9 @@ class DrClient:
         logger.info("Custom model version created successfully (id: %s)", model_version["id"])
         return model_version
 
-    def create_or_update_registered_model(self, custom_model_version_id, registered_model_name):
+    def create_or_update_registered_model(
+        self, custom_model_version_id, registered_model_name, registered_model_description
+    ):
         """
         Creates or updates a registered model from custom model version.
         If a registered model named registered_model_name exists, it is updated with a new
@@ -496,15 +498,17 @@ class DrClient:
             registered_model_name = None
 
         model_package = self.create_model_package_from_custom_model_version(
-            custom_model_version_id, registered_model_name, registered_model_id
+            custom_model_version_id,
+            registered_model_name,
+            registered_model_id,
+            registered_model_description,
         )
 
         return model_package["id"]
 
-    def set_registered_model_global(self, registered_model_name, is_global):
+    def update_registered_model(self, registered_model_name, is_global):
         """
-        Set the global property for a registered model.
-        This is also known as the global property
+        Updates registered model properties.
 
         Parameters
         ----------
@@ -1271,7 +1275,11 @@ class DrClient:
         return deployment
 
     def create_model_package_from_custom_model_version(
-        self, custom_model_version_id, registered_model_name=None, registered_model_id=None
+        self,
+        custom_model_version_id,
+        registered_model_name=None,
+        registered_model_id=None,
+        registered_model_description=None,
     ):
         """
         Creates a model package in the model's registry from a custom model version.
@@ -1300,6 +1308,8 @@ class DrClient:
             payload["registeredModelName"] = registered_model_name
         if registered_model_id:
             payload["registeredModelId"] = registered_model_id
+        if registered_model_description:
+            payload["registeredModelDescription"] = registered_model_description
 
         response = self._http_requester.post(self.MODEL_PACKAGES_CREATE_ROUTE, json=payload)
         if response.status_code != 201:

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -455,9 +455,7 @@ class DrClient:
         logger.info("Custom model version created successfully (id: %s)", model_version["id"])
         return model_version
 
-    def create_or_update_registered_model(
-        self, custom_model_version_id, registered_model_name, registered_model_description
-    ):
+    def create_or_update_registered_model(self, custom_model_version_id, registered_model_name):
         """
         Creates or updates a registered model from custom model version.
         If a registered model named registered_model_name exists, it is updated with a new
@@ -501,7 +499,6 @@ class DrClient:
             custom_model_version_id,
             registered_model_name,
             registered_model_id,
-            registered_model_description,
         )
 
         return model_package["id"]
@@ -1291,7 +1288,6 @@ class DrClient:
         custom_model_version_id,
         registered_model_name=None,
         registered_model_id=None,
-        registered_model_description=None,
     ):
         """
         Creates a model package in the model's registry from a custom model version.
@@ -1320,8 +1316,6 @@ class DrClient:
             payload["registeredModelName"] = registered_model_name
         if registered_model_id:
             payload["registeredModelId"] = registered_model_id
-        if registered_model_description:
-            payload["registeredModelDescription"] = registered_model_description
 
         response = self._http_requester.post(self.MODEL_PACKAGES_CREATE_ROUTE, json=payload)
         if response.status_code != 201:

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -506,7 +506,7 @@ class DrClient:
 
         return model_package["id"]
 
-    def update_registered_model(self, registered_model_name, is_global):
+    def update_registered_model(self, registered_model_name, description, is_global):
         """
         Updates registered model properties.
 
@@ -514,6 +514,8 @@ class DrClient:
         ----------
         registered_model_name : str
             Name of registered model.
+        description : str
+            Description of registered model.
         is_global : bool
             True if model should be global, False if not.
         """
@@ -523,15 +525,25 @@ class DrClient:
                 f"Failed to find registered model by name: {registered_model_name}"
             )
 
-        if registered_model.get("isGlobal", None) == is_global:
+        payload = {}
+
+        if description is not None and description != registered_model["description"]:
+            payload["description"] = description
+
+        if is_global is not None and is_global != registered_model.get("isGlobal", None):
+            payload["isGlobal"] = is_global
+
+        if not payload:
             logger.info(
-                "Registered model '%s' global flag is already: %s", registered_model_name, is_global
+                "Registered model '%s' settings are already up to date: %s",
+                registered_model_name,
+                is_global,
             )
             return
 
         response = self._http_requester.patch(
             self.REGISTERED_MODEL_ROUTE.format(registered_model_id=registered_model["id"]),
-            json={"isGlobal": is_global},
+            json=payload,
         )
         if response.status_code != 200:
             raise DataRobotClientError(

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -633,7 +633,7 @@ class ModelController(ControllerBase):
                 self._dr_client.create_or_update_registered_model(
                     latest_version["id"], model_info.registered_model_name
                 )
-                self._dr_client.set_registered_model_global(
+                self._dr_client.update_registered_model(
                     model_info.registered_model_name, model_info.registered_model_global
                 )
 

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -634,7 +634,9 @@ class ModelController(ControllerBase):
                     latest_version["id"], model_info.registered_model_name
                 )
                 self._dr_client.update_registered_model(
-                    model_info.registered_model_name, model_info.registered_model_global
+                    model_info.registered_model_name,
+                    model_info.registered_model_description,
+                    model_info.registered_model_global,
                 )
 
     @staticmethod

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -367,6 +367,11 @@ class ModelInfo(InfoBase):
         return self.get_value(ModelSchema.MODEL_REGISTRY_KEY, ModelSchema.MODEL_NAME)
 
     @property
+    def registered_model_description(self):
+        """The registered model description to use or None if model should not be registered."""
+        return self.get_value(ModelSchema.MODEL_REGISTRY_KEY, ModelSchema.MODEL_DESCRIPTION)
+
+    @property
     def registered_model_global(self):
         """Wheter the registered model should be global or not."""
         return self.get_value(ModelSchema.MODEL_REGISTRY_KEY, ModelSchema.GLOBAL)

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -284,6 +284,7 @@ class ModelSchema(SharedSchema):
 
     MODEL_REGISTRY_KEY = "model_registry"
     MODEL_NAME = "model_name"
+    MODEL_DESCRIPTION = "model_description"
     GLOBAL = "global"
 
     MODEL_SCHEMA = Schema(
@@ -382,6 +383,7 @@ class ModelSchema(SharedSchema):
             },
             Optional(MODEL_REGISTRY_KEY): {
                 Optional(MODEL_NAME): And(str, len),
+                Optional(MODEL_DESCRIPTION): And(str, len),
                 Optional(GLOBAL, default=False): bool,
             },
         }

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -1506,7 +1506,6 @@ class TestRegisteredModels:
             registered_model = {
                 "id": "existing_registered_model_id",
                 "name": "existing_registered_model",
-                "description": "model_description",
             }
 
             params = {"search": registered_model["name"]}
@@ -1531,7 +1530,6 @@ class TestRegisteredModels:
         create_model_package_payload = {
             "customModelVersionId": "custom_model_version_id",
             "registeredModelName": "non_existent_registered_model",
-            "registeredModelDescription": "model_description",
         }
 
         responses.post(
@@ -1542,7 +1540,7 @@ class TestRegisteredModels:
         )
 
         registered_model_version = dr_client.create_or_update_registered_model(
-            "custom_model_version_id", "non_existent_registered_model", "model_description"
+            "custom_model_version_id", "non_existent_registered_model"
         )
 
         assert registered_model_version == "new_registered_model_id"
@@ -1569,7 +1567,6 @@ class TestRegisteredModels:
         create_model_package_payload = {
             "customModelVersionId": custom_model_version_id,
             "registeredModelId": registered_model_response_mock["id"],
-            "registeredModelDescription": registered_model_response_mock["description"],
         }
         new_registered_model_id = "new_registered_model_id"
         responses.post(
@@ -1581,7 +1578,6 @@ class TestRegisteredModels:
         registered_model_version = dr_client.create_or_update_registered_model(
             custom_model_version_id,
             registered_model_response_mock["name"],
-            registered_model_response_mock["description"],
         )
 
         assert registered_model_version == new_registered_model_id
@@ -1613,7 +1609,6 @@ class TestRegisteredModels:
         registered_model_version = dr_client.create_or_update_registered_model(
             custom_model_version_id,
             registered_model_response_mock["name"],
-            registered_model_response_mock["description"],
         )
 
         assert registered_model_version == registered_model_version_id


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
We want to be able to set the description for global models.
<!-- For efficient review please explain "why" you are making this change. -->


## CHANGES
Changed method `set_registered_model_global` into a more generic method `update_registered_model` that supports updating properties for a registered model.
<!-- List the changes in this PR, in highlights. -->


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
