### PR TITLE
[CODEGEN-1766] Fix creating new custom version when not needed

### DIFF
--- a/src/custom_models_action.py
+++ b/src/custom_models_action.py
@@ -83,16 +83,6 @@ class CustomModelsAction:
     def _prerequisites(self):
         """Check prerequisites before execution."""
 
-        supported_events = ["push", "pull_request"]
-        if GitHubEnv.event_name() not in supported_events:
-            logger.warning(
-                "Skip custom models action. It is expected to be executed only "
-                "on %s events. Current event: %s.",
-                supported_events,
-                GitHubEnv.event_name(),
-            )
-            return False
-
         base_ref = GitHubEnv.base_ref()
         logger.info("GITHUB_BASE_REF: %s.", base_ref)
         if GitHubEnv.is_pull_request() and base_ref != self._options.branch:

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -532,9 +532,8 @@ class DrClient:
 
         if not payload:
             logger.info(
-                "Registered model '%s' settings are already up to date: %s",
+                "Registered model '%s' properties are already up to date.",
                 registered_model_name,
-                is_global,
             )
             return
 
@@ -544,7 +543,7 @@ class DrClient:
         )
         if response.status_code != 200:
             raise DataRobotClientError(
-                "Failed to set registered global property "
+                "Failed to update registered model properties "
                 f"Registered model name: {registered_model_name}, "
                 f"Response status: {response.status_code}, "
                 f"Response body: {response.text}",
@@ -552,9 +551,9 @@ class DrClient:
             )
 
         logger.info(
-            "Registered model '%s' global flag has been set to: %s",
+            "Registered model '%s' properties have been updated with payload: %s",
             registered_model_name,
-            is_global,
+            payload,
         )
 
     def get_registered_model_by_name(self, registered_model_name):

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -284,9 +284,11 @@ class ModelInfo(InfoBase):
 
         print(self.flags.should_update_settings)
         print(self.should_create_new_version(datarobot_latest_model_version))
-        print(self.is_there_a_change_in_training_or_holdout_data_at_version_level(
+        print(
+            self.is_there_a_change_in_training_or_holdout_data_at_version_level(
                 datarobot_latest_model_version
-            ))
+            )
+        )
         return (
             self.flags.should_update_settings
             or self.should_create_new_version(datarobot_latest_model_version)
@@ -317,7 +319,9 @@ class ModelInfo(InfoBase):
             (ModelSchema.EGRESS_NETWORK_POLICY_KEY, "networkEgressPolicy"),
         ):
             configured_resource = self.get_value(ModelSchema.VERSION_KEY, resource_key)
-            if configured_resource != datarobot_latest_model_version.get(dr_attribute_key):
+            if configured_resource and configured_resource != datarobot_latest_model_version.get(
+                dr_attribute_key
+            ):
                 print(resource_key)
                 print(configured_resource)
                 print(datarobot_latest_model_version.get(dr_attribute_key))

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -282,6 +282,11 @@ class ModelInfo(InfoBase):
     def is_affected_by_commit(self, datarobot_latest_model_version):
         """Whether the given model is affected by the last commit"""
 
+        print(self.flags.should_update_settings)
+        print(self.should_create_new_version(datarobot_latest_model_version))
+        print(self.is_there_a_change_in_training_or_holdout_data_at_version_level(
+                datarobot_latest_model_version
+            ))
         return (
             self.flags.should_update_settings
             or self.should_create_new_version(datarobot_latest_model_version)

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -293,6 +293,11 @@ class ModelInfo(InfoBase):
     def should_create_new_version(self, datarobot_latest_model_version):
         """Whether a new custom inference model version should be created"""
 
+        print(datarobot_latest_model_version)
+        print(self.flags.should_upload_all_files)
+        print(self.file_changes.changed_or_new_files)
+        print(self.file_changes.deleted_file_ids)
+
         if (
             not datarobot_latest_model_version
             or self.flags.should_upload_all_files
@@ -308,6 +313,9 @@ class ModelInfo(InfoBase):
         ):
             configured_resource = self.get_value(ModelSchema.VERSION_KEY, resource_key)
             if configured_resource != datarobot_latest_model_version.get(dr_attribute_key):
+                print(resource_key)
+                print(configured_resource)
+                print(datarobot_latest_model_version.get(dr_attribute_key))
                 return True
 
         return False

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -282,13 +282,6 @@ class ModelInfo(InfoBase):
     def is_affected_by_commit(self, datarobot_latest_model_version):
         """Whether the given model is affected by the last commit"""
 
-        print(self.flags.should_update_settings)
-        print(self.should_create_new_version(datarobot_latest_model_version))
-        print(
-            self.is_there_a_change_in_training_or_holdout_data_at_version_level(
-                datarobot_latest_model_version
-            )
-        )
         return (
             self.flags.should_update_settings
             or self.should_create_new_version(datarobot_latest_model_version)
@@ -300,17 +293,20 @@ class ModelInfo(InfoBase):
     def should_create_new_version(self, datarobot_latest_model_version):
         """Whether a new custom inference model version should be created"""
 
-        print(datarobot_latest_model_version)
-        print(self.flags.should_upload_all_files)
-        print(self.file_changes.changed_or_new_files)
-        print(self.file_changes.deleted_file_ids)
-
         if (
             not datarobot_latest_model_version
             or self.flags.should_upload_all_files
             or bool(self.file_changes.changed_or_new_files)
             or bool(self.file_changes.deleted_file_ids)
         ):
+            logger.debug(
+                "Need to create new version. datarobot_latest_model_version:%s "
+                "should_upload_all_files:%s changed_or_new_files:%s deleted_file_ids:%s",
+                datarobot_latest_model_version,
+                self.flags.should_upload_all_files,
+                self.file_changes.changed_or_new_files,
+                self.file_changes.deleted_file_ids,
+            )
             return True
 
         for resource_key, dr_attribute_key in (
@@ -322,9 +318,13 @@ class ModelInfo(InfoBase):
             if configured_resource and configured_resource != datarobot_latest_model_version.get(
                 dr_attribute_key
             ):
-                print(resource_key)
-                print(configured_resource)
-                print(datarobot_latest_model_version.get(dr_attribute_key))
+                logger.debug(
+                    "Need to create new version. Resource '%s' changed. "
+                    "Configured value: '%s' Value on server: '%s'",
+                    resource_key,
+                    configured_resource,
+                    datarobot_latest_model_version.get(dr_attribute_key),
+                )
                 return True
 
         return False
@@ -348,6 +348,7 @@ class ModelInfo(InfoBase):
             "dataset_id"
         )
         if configured_training_dataset != latest_training_dataset:
+            logger.debug("Configured training dataset != latest training dataset")
             return True
 
         # Check holdout
@@ -359,6 +360,7 @@ class ModelInfo(InfoBase):
                 "dataset_id"
             )
             if configured_holdout_dataset != latest_holdout_dataset:
+                logger.debug("Configured holdout dataset != latest holdout dataset")
                 return True
 
         else:
@@ -369,6 +371,7 @@ class ModelInfo(InfoBase):
                 "partition_column"
             )
             if configured_holdout_partition != latest_partition:
+                logger.debug("Configured holdout partition != latest holdout partition")
                 return True
 
         return False


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONALE
`ModelInfo.should_create_new_version()` will return true because the default value for `networkEgressPolicy` serverside is something different than `None`. `DrClient._setup_payload_for_custom_model_version_creation()` will however not add `networkEgressPolicy` to the payload when the desired value is `None`. The result is that `networkEgressPolicy` remains unchanged and the next time the action is run, the same thing repeats.

## CHANGES
* Only consider if a property has changed if it is not `None`. This will make the behavior in `ModelInfo.should_create_new_version()` consistent with `DrClient._setup_payload_for_custom_model_version_creation()` 
* Add additional debug logging to make it easier to figure out why a new version is created.
* Remove check that exits if Github Actions event is not push or pull_request. This is done because we want to run the action on `workflow_dispatch` event in global-envs-models repo.


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
