### PR TITLE
[CODEGEN-1834] Support resource bundle for custom model version

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -625,6 +625,12 @@ class DrClient:
         if egress_network_policy:
             payload.append(("networkEgressPolicy", str(egress_network_policy)))
 
+        resource_bundle_id = model_info.get_value(
+            ModelSchema.VERSION_KEY, ModelSchema.RESOURCE_BUNDLE_ID
+        )
+        if resource_bundle_id:
+            payload.append(("resourceBundleId", resource_bundle_id))
+
         return payload, file_objs
 
     @staticmethod

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -314,6 +314,7 @@ class ModelInfo(InfoBase):
             (ModelSchema.MEMORY_KEY, "maximumMemory"),
             (ModelSchema.REPLICAS_KEY, "replicas"),
             (ModelSchema.EGRESS_NETWORK_POLICY_KEY, "networkEgressPolicy"),
+            (ModelSchema.RESOURCE_BUNDLE_ID, "resourceBundleId"),
         ):
             configured_resource = self.get_value(ModelSchema.VERSION_KEY, resource_key)
             if configured_resource and configured_resource != datarobot_latest_model_version.get(

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -248,6 +248,8 @@ class ModelSchema(SharedSchema):
     EGRESS_NETWORK_POLICY_NONE = "NONE"
     EGRESS_NETWORK_POLICY_PUBLIC = "PUBLIC"
 
+    RESOURCE_BUNDLE_ID = "resource_bundle_id"
+
     MODEL_REPLACEMENT_REASON_KEY = "model_replacement_reason"
     MODEL_REPLACEMENT_REASON_ACCURACY = "ACCURACY"
     MODEL_REPLACEMENT_REASON_DATA_DRIFT = "DATA_DRIFT"
@@ -327,6 +329,7 @@ class ModelSchema(SharedSchema):
                 Optional(EGRESS_NETWORK_POLICY_KEY): Or(
                     EGRESS_NETWORK_POLICY_NONE, EGRESS_NETWORK_POLICY_PUBLIC
                 ),
+                Optional(RESOURCE_BUNDLE_ID): And(str, len),
                 Optional(PARTITIONING_COLUMN_KEY): And(str, len),
                 Optional(TRAINING_DATASET_ID_KEY): And(str, ObjectId.is_valid),
                 Optional(HOLDOUT_DATASET_ID_KEY): And(str, ObjectId.is_valid),


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
Resource bundles is the new way to specify what kind of resources a custom model requires which supports GPU resources.
<!-- For efficient review please explain "why" you are making this change. -->


## CHANGES
* Add resource_bundle field and make sure it is submitted when creating new custom model version.
<!-- List the changes in this PR, in highlights. -->


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
