### PR TITLE
[RAPTOR-12005] Custom Models Action: Wait for successful model package creation before deploying

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from common.github_env import GitHubEnv
 def unique_str():
     """Generate a unique 10-chars long string."""
 
-    return f"{random.randint(1, 2 ** 32): 010}"
+    return f"{random.randint(1, 2 ** 32):010}"
 
 
 @pytest.fixture

--- a/tests/functional/test_deployment_github_actions.py
+++ b/tests/functional/test_deployment_github_actions.py
@@ -543,7 +543,7 @@ class TestDeploymentGitHubActions:
     def _validate_deployments_metric(metric, event_name, github_output_filepath):
         with open(github_output_filepath, "r", encoding="utf-8") as file:
             github_output_content = file.read()
-        metric_label = metric.user_facing_name(constants.Label.DEPLOYMENTS)
+        metric_label = metric.user_facing_name(constants.Label.DEPLOYMENTS.value)
         pattern = f"{metric_label}=(.*)"
         items = re.findall(pattern, github_output_content)
         assert len(items) == 1, (

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -1517,6 +1517,14 @@ class TestRegisteredModels:
 
             yield registered_model
 
+    @pytest.fixture
+    def patch_wait_for_async_resolution(self):
+        """Patch wait for async resolution method."""
+
+        with patch.object(DrClient, "_wait_for_async_resolution"):
+            yield
+
+    @pytest.mark.usefixtures("patch_wait_for_async_resolution")
     @responses.activate
     def test_create_new_registered_model(self, dr_client, paginated_url_factory):
         """Test creating new registered model"""
@@ -1535,6 +1543,7 @@ class TestRegisteredModels:
         responses.post(
             url=paginated_url_factory(DrClient.MODEL_PACKAGES_CREATE_ROUTE),
             match=[matchers.json_params_matcher(create_model_package_payload)],
+            headers={"Location": "https://dr/api/v2/status/67baedd52a54aeda01837ccb"},
             json={"id": "new_registered_model_id"},
             status=201,
         )
@@ -1545,6 +1554,7 @@ class TestRegisteredModels:
 
         assert registered_model_version == "new_registered_model_id"
 
+    @pytest.mark.usefixtures("patch_wait_for_async_resolution")
     @responses.activate
     def test_update_existing_registered_model(
         self,
@@ -1572,6 +1582,7 @@ class TestRegisteredModels:
         responses.post(
             url=paginated_url_factory(DrClient.MODEL_PACKAGES_CREATE_ROUTE),
             match=[matchers.json_params_matcher(create_model_package_payload)],
+            headers={"Location": "https://dr/api/v2/status/67baedd52a54aeda01837ccb"},
             json={"id": new_registered_model_id},
             status=201,
         )


### PR DESCRIPTION
## RATIONAL
Previously, users could create a model package and immediately proceed to create deployment without waiting for successful package creation. This is no longer permitted; users must wait for the model package to build successfully before deploying.

## CHANGES
* Wait for a successful model's package creation, before proceeding to deployment's creation.
* One bug fix regarding to Enum value.
* Minor linting fixes.


----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
