### PR TITLE
[RAPTOR-12007] Custom Models Action: Make model example dummy to avoid compatibility with a given ML package

### DIFF
--- a/tests/models/py3_sklearn/custom.py
+++ b/tests/models/py3_sklearn/custom.py
@@ -3,9 +3,30 @@
 #  This is proprietary source code of DataRobot, Inc. and its affiliates.
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 
+from typing import Any
+from typing import Dict
+
+import pandas as pd
+
 """
 A super simple example of custom model body with a single 'transform' hook.
 """
+
+
+def load_model(code_dir: str) -> Any:
+    """
+    Can be used to load supported models if your model has multiple artifacts, or for loading
+    models that **drum** does not natively support
+
+    Parameters
+    ----------
+    code_dir : is the directory where model artifact and additional code are provided, passed in
+
+    Returns
+    -------
+    If used, this hook must return a non-None value
+    """
+    return "dummy"
 
 
 def transform(data, model):
@@ -32,3 +53,31 @@ def transform(data, model):
             data.pop(unused_column)
     data = data.fillna(0)
     return data
+
+
+def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFrame:
+    """
+    This hook is only needed if you would like to use **drum** with a framework not natively
+    supported by the tool.
+
+    Note: While best practice is to include the score hook, if the score hook is not present
+    DataRobot will add a score hook and call the default predict method for the library
+    See https://github.com/datarobot/datarobot-user-models#built-in-model-support for details
+
+    This dummy implementation returns a dataframe with all rows having value 42 in the
+    "Predictions" column, regardless of the provided input dataset.
+
+    Parameters
+    ----------
+    data : is the dataframe to make predictions against. If `transform` is supplied,
+    `data` will be the transformed data.
+    model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+    kwargs : additional keyword arguments to the method
+
+    Returns
+    -------
+    This method should return predictions as a dataframe with the following format:
+      Regression: must have a single column called `Predictions` with numerical values
+    """
+    preds = pd.DataFrame([42 for _ in range(data.shape[0])], columns=["Predictions"])
+    return preds


### PR DESCRIPTION
## RATIONAL
Previously, the tests used a custom model that included a generated scikit-learn model artifact. This caused incompatibility with newer drop-in execution environments due to updated scikit-learn versions. However, for testing purposes, using a model artifact is unnecessary. A dummy model can be used instead.


## CHANGES
* Remove the `sklearn_reg.pkl` model artifact and instead load a dummy model.

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
