### PR TITLE
[RAPTOR-12008] Custom Models Action: Remove training/holdout tests at model level as DataRobot defaults to model version

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -759,7 +759,7 @@ def upload_and_update_dataset(
 
 @contextlib.contextmanager
 def temporarily_upload_training_dataset_for_structured_model(
-    dr_client, model_metadata_yaml_file, is_model_level, event_name
+    dr_client, model_metadata_yaml_file, event_name
 ):
     """A method to temporarily upload a training dataset for a structured model."""
 
@@ -771,9 +771,7 @@ def temporarily_upload_training_dataset_for_structured_model(
         training_and_holdout_dataset_filepath = (
             datasets_root / "juniors_3_year_stats_regression_structured_training_with_holdout.csv"
         )
-        section_key = (
-            ModelSchema.SETTINGS_SECTION_KEY if is_model_level else ModelSchema.VERSION_KEY
-        )
+        section_key = ModelSchema.VERSION_KEY
         with upload_and_update_dataset(
             dr_client,
             training_and_holdout_dataset_filepath,

--- a/tests/functional/test_deployment_github_actions.py
+++ b/tests/functional/test_deployment_github_actions.py
@@ -492,7 +492,7 @@ class TestDeploymentGitHubActions:
         """An end-to-end case to test changes in deployment settings."""
 
         with temporarily_upload_training_dataset_for_structured_model(
-            dr_client, model_metadata_yaml_file, is_model_level=False, event_name=event_name
+            dr_client, model_metadata_yaml_file, event_name=event_name
         ):
             try:
                 # Run the GitHub action to create a model and deployment
@@ -731,7 +731,7 @@ class TestDeploymentGitHubActions:
             == new_deployment_settings["predictionsDataCollection"]["enabled"]
         )
         cls._validate_deployments_metric(
-            Metric("total_updated_settings"), event_name, github_output
+            Metric("total-updated-settings"), event_name, github_output
         )
 
     @contextlib.contextmanager


### PR DESCRIPTION
## RATIONAL
Training and holdout dataset assignments are now set by default at the model version level in DataRobot. As a result, custom model actions should be adjusted to test cases at the model version level only.

## CHANGES
* Remove training / holdeout dataset assignment tests at the model's level.
* Refactor the code to reflect the given change.

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
