### PR TITLE
[RAPTOR-12009] Allow execution environment version in model metadata

### DIFF
--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -422,6 +422,9 @@ class DrClient:
             base_env_id = model_info.get_value(
                 ModelSchema.VERSION_KEY, ModelSchema.MODEL_ENV_ID_KEY
             )
+            base_env_version_id = model_info.get_value(
+                ModelSchema.VERSION_KEY, ModelSchema.MODEL_ENV_VERSION_ID_KEY
+            )
             payload, file_objs = self._setup_payload_for_custom_model_version_creation(
                 is_major_update,
                 model_info,
@@ -429,6 +432,7 @@ class DrClient:
                 changed_file_paths,
                 file_ids_to_delete=file_ids_to_delete,
                 base_env_id=base_env_id,
+                base_env_version_id=base_env_version_id,
             )
             mp_encoder = MultipartEncoder(fields=payload)
             headers = {"Content-Type": mp_encoder.content_type}
@@ -590,6 +594,7 @@ class DrClient:
         changed_file_paths,
         file_ids_to_delete=None,
         base_env_id=None,
+        base_env_version_id=None,
     ):
         payload = [
             ("isMajorUpdate", str(is_major_update)),
@@ -610,6 +615,9 @@ class DrClient:
 
         if base_env_id:
             payload.append(("baseEnvironmentId", base_env_id))
+
+        if base_env_version_id:
+            payload.append(("baseEnvironmentVersionId", base_env_version_id))
 
         memory = model_info.get_value(ModelSchema.VERSION_KEY, ModelSchema.MEMORY_KEY)
         if memory:
@@ -2181,7 +2189,7 @@ class DrClient:
         ----------
         search_for : str or None
             Optional. A string to filter out environments in DataRobot. The search is done
-            in the name and description of every environment drop-in, and it is case insensitive.
+            in the name and description of every environment drop-in, and it is case-insensitive.
 
         Returns
         -------

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -311,6 +311,7 @@ class ModelInfo(InfoBase):
 
         for resource_key, dr_attribute_key in (
             (ModelSchema.MODEL_ENV_ID_KEY, "baseEnvironmentId"),
+            (ModelSchema.MODEL_ENV_VERSION_ID_KEY, "baseEnvironmentVersionId"),
             (ModelSchema.MEMORY_KEY, "maximumMemory"),
             (ModelSchema.REPLICAS_KEY, "replicas"),
             (ModelSchema.EGRESS_NETWORK_POLICY_KEY, "networkEgressPolicy"),

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -240,6 +240,7 @@ class ModelSchema(SharedSchema):
 
     VERSION_KEY = "version"
     MODEL_ENV_ID_KEY = "model_environment_id"
+    MODEL_ENV_VERSION_ID_KEY = "model_environment_version_id"
     INCLUDE_GLOB_KEY = "include_glob_pattern"
     EXCLUDE_GLOB_KEY = "exclude_glob_pattern"
     MEMORY_KEY = "memory"
@@ -316,6 +317,7 @@ class ModelSchema(SharedSchema):
             },
             VERSION_KEY: {
                 MODEL_ENV_ID_KEY: And(str, ObjectId.is_valid),
+                Optional(MODEL_ENV_VERSION_ID_KEY): And(str, ObjectId.is_valid),
                 Optional(INCLUDE_GLOB_KEY, default=[]): And(
                     list, lambda lst: all(isinstance(e, str) and len(e) > 0 for e in lst)
                 ),

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -489,6 +489,7 @@ def mock_full_binary_model_schema(mock_full_custom_model_checks):
         },
         ModelSchema.VERSION_KEY: {
             ModelSchema.MODEL_ENV_ID_KEY: "627790db5621558eedc4c7fa",
+            ModelSchema.MODEL_ENV_VERSION_ID_KEY: "67bb32e541aa2d6ec17cd6f3",
             ModelSchema.INCLUDE_GLOB_KEY: ["./"],
             ModelSchema.EXCLUDE_GLOB_KEY: ["README.md", "out/"],
             ModelSchema.MEMORY_KEY: "100Mi",

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -112,6 +112,7 @@ def fixture_regression_model_info():
         },
         ModelSchema.VERSION_KEY: {
             ModelSchema.MODEL_ENV_ID_KEY: "627790db5621558eedc4c7fa",
+            ModelSchema.MODEL_ENV_VERSION_ID_KEY: "67bb4397c2d6609d0075b104",
             ModelSchema.INCLUDE_GLOB_KEY: ["./"],
             ModelSchema.EXCLUDE_GLOB_KEY: ["README.md", "out/"],
             ModelSchema.MEMORY_KEY: 256 * 1024 * 1024,


### PR DESCRIPTION
## RATIONAL
Enable users to specify the execution environment version ID in the model's metadata YAML file.


## CHANGES
* Update the model metadata schema to support specifying the execution environment version ID under the version section.
* Include the execution environment version ID in the model version's creation payload if provided.
* Add/update tests

-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
