### PR TITLE
[BUZZOK-25903] Add `--exclude`, allowing exclusion of model yaml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The action supports the following optional input arguments:
 | `--allow-model-deletion`      | Determines whether to detect local deleted model definitions and delete them in DataRobot <br> **Default**: `false`       |
 | `--models-only`               | Determines whether to manage custom inference models only or also deployments <br> **Default**: `false`                   |
 | `--skip-cert-verification`    | Determines whether a request to an HTTPS URL is made without a certificate verification. <br> **Default**: `false`        |
+| `--exclude`                   | Regex pattern to exclude YAML files from being processed. Can match any part of the file path.                            |
 
 ### A Namespace (Optional)
 

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
       Whether a request to an HTTPS URL will be made without a certificate verification.
     required: false
     default: 'false'
+  exclude:
+    description: |
+      Regex pattern to exclude YAML files from being processed. Can match any part of the file path.
+    required: false
 outputs:
   models--total-affected: # id of output
     description: 'The total number of models that were affected.'
@@ -84,6 +88,7 @@ runs:
         ${{ inputs.allow-deployment-deletion == 'true' }} && allow_deployment_deletion_arg='--allow-deployment-deletion'
         ${{ inputs.models_only == 'true' }} && models_only_arg='--models-only'
         ${{ inputs.skip-cert-verification == 'true' }} && verify_cert_arg='--skip-cert-verification'
+        ${{ inputs.exclude != '' }} && exclude_arg='--exclude ${{ inputs.exclude }}'
 
         python ${GITHUB_ACTION_PATH}/src/main.py \
           --api-token ${{ inputs.api-token }} \
@@ -93,5 +98,6 @@ runs:
           ${allow_model_deletion_arg} \
           ${allow_deployment_deletion_arg} \
           ${models_only_arg} \
-          ${verify_cert_arg}
+          ${verify_cert_arg} \
+          ${exclude_arg}
       shell: bash

--- a/src/main.py
+++ b/src/main.py
@@ -50,6 +50,10 @@ def argparse_options(args=None):
         "--namespace", help="It is used to group and isolate models and deployments."
     )
     parser.add_argument(
+        "--exclude",
+        help="Regex pattern to exclude YAML files from being processed. Can match any part of the file path."
+    )
+    parser.add_argument(
         "--allow-model-deletion",
         action="store_true",
         help="Whether to detect local deleted model definitions and consequently delete them in "

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -331,6 +331,7 @@ def options(workspace_path):
             allow_deployment_deletion=True,
             skip_cert_verification=True,
             models_only=False,
+            exclude=None,
         )
 
 

--- a/tests/unit/test_custom_inference_model.py
+++ b/tests/unit/test_custom_inference_model.py
@@ -514,6 +514,7 @@ class TestGlobPatterns:
             api_token="abc",
             skip_cert_verification=True,
             branch="master",
+            exclude=None,
         )
         with patch.object(
             ModelController, "models_info", new_callable=PropertyMock

--- a/tests/unit/test_yaml_exclusion.py
+++ b/tests/unit/test_yaml_exclusion.py
@@ -1,0 +1,70 @@
+#  Copyright (c) 2022. DataRobot, Inc. and its affiliates.
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+
+"""Unit tests for YAML file exclusion functionality."""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from model_controller import ModelController
+
+
+@pytest.mark.parametrize(
+    "exclude_pattern,expected_files",
+    [
+        (None, ["model1.yaml", "model2.yaml"]),  # No exclude pattern
+        ("test/", ["model1.yaml"]),  # Simple exclude
+        (".*test.*\.yaml$", ["model1.yaml"]),  # Complex regex
+        ("", ["model1.yaml", "model2.yaml"]),  # Empty pattern
+        ("model[12]\\.yaml", []),  # All models
+    ],
+)
+def test_yaml_file_exclusion(options, exclude_pattern, expected_files, workspace_path):
+    """Test that YAML files are properly excluded based on the exclude pattern."""
+    options.exclude = exclude_pattern
+    options.workspace_path = workspace_path  # Set workspace path in options
+    
+    # Create test files with valid YAML content
+    model1_content = {
+        "user_provided_model_id": "test/model1",
+        "target_type": "Regression",
+        "settings": {
+            "name": "Test Model 1",
+            "target_name": "target"
+        },
+        "version": {
+            "model_environment_id": "5e8c889607389fe0f466c72d"
+        }
+    }
+    
+    model2_content = {
+        "user_provided_model_id": "test/model2",
+        "target_type": "Regression",
+        "settings": {
+            "name": "Test Model 2",
+            "target_name": "target"
+        },
+        "version": {
+            "model_environment_id": "5e8c889607389fe0f466c72d"
+        }
+    }
+    
+    # Create directories and write YAML files
+    os.makedirs(workspace_path / "test", exist_ok=True)
+    with open(workspace_path / "model1.yaml", "w") as f:
+        yaml.dump(model1_content, f)
+    with open(workspace_path / "test/model2.yaml", "w") as f:
+        yaml.dump(model2_content, f)
+    
+    controller = ModelController(options, None)
+    
+    # Collect processed files
+    processed_files = [path for path, _ in controller._next_yaml_content_in_repo()]
+    processed_files = [Path(p).name for p in processed_files]
+    
+    assert set(processed_files) == set(expected_files) 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->

Allow excluding `.yaml` / `.yml` files from being picked up by the GH action, using a regex parameter.

## CHANGES
<!-- List the changes in this PR, in highlights. -->


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
