### PR TITLE
[BUZZOK-25903] Fix for when exclude is not passed

### DIFF
--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -59,7 +59,7 @@ class ControllerBase(ABC):
             verify_cert=not self.options.skip_cert_verification,
         )
         self._metrics = Metrics(self._label())
-        self._exclude_pattern = re.compile(options.exclude) if hasattr(options, "exclude") else None
+        self._exclude_pattern = re.compile(options.exclude) if getattr(options, "exclude", None) else None
         logger.info(
             "GITHUB_EVENT_NAME: %s, GITHUB_SHA: %s, GITHUB_REPOSITORY: %s, GITHUB_REF_NAME: %s",
             GitHubEnv.event_name(),


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data, code, datasets, model artifacts, .etc.

## RATIONAL
<!-- For efficient review please explain "why" you are making this change. -->

When no `--exclude` is supplied, the attribute will exist but the value will be `None`, which leads to attempts to `re.compile(None)`.

## CHANGES
<!-- List the changes in this PR, in highlights. -->


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.
