### PR TITLE
[RAPTOR-19448] Upstream key_values into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The action supports the following optional input arguments:
 | `--allow-model-deletion`      | Determines whether to detect local deleted model definitions and delete them in DataRobot <br> **Default**: `false`       |
 | `--models-only`               | Determines whether to manage custom inference models only or also deployments <br> **Default**: `false`                   |
 | `--skip-cert-verification`    | Determines whether a request to an HTTPS URL is made without a certificate verification. <br> **Default**: `false`        |
+| `--exclude`                   | Regex pattern to exclude YAML files from being processed. Can match any part of the file path.                            |
 
 ### A Namespace (Optional)
 

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
       Whether a request to an HTTPS URL will be made without a certificate verification.
     required: false
     default: 'false'
+  exclude:
+    description: |
+      Regex pattern to exclude YAML files from being processed. Can match any part of the file path.
+    required: false
 outputs:
   models--total-affected: # id of output
     description: 'The total number of models that were affected.'
@@ -84,6 +88,7 @@ runs:
         ${{ inputs.allow-deployment-deletion == 'true' }} && allow_deployment_deletion_arg='--allow-deployment-deletion'
         ${{ inputs.models_only == 'true' }} && models_only_arg='--models-only'
         ${{ inputs.skip-cert-verification == 'true' }} && verify_cert_arg='--skip-cert-verification'
+        ${{ inputs.exclude != '' }} && exclude_arg='--exclude ${{ inputs.exclude }}'
 
         python ${GITHUB_ACTION_PATH}/src/main.py \
           --api-token ${{ inputs.api-token }} \
@@ -93,5 +98,6 @@ runs:
           ${allow_model_deletion_arg} \
           ${allow_deployment_deletion_arg} \
           ${models_only_arg} \
-          ${verify_cert_arg}
+          ${verify_cert_arg} \
+          ${exclude_arg}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -83,21 +83,17 @@ runs:
       shell: bash
     - id: custom-models-action
       run: |
-        ${{ inputs.namespace != '' }} && namespace_arg='--namespace ${{ inputs.namespace }}'
-        ${{ inputs.allow-model-deletion == 'true' }} && allow_model_deletion_arg='--allow-model-deletion'
-        ${{ inputs.allow-deployment-deletion == 'true' }} && allow_deployment_deletion_arg='--allow-deployment-deletion'
-        ${{ inputs.models_only == 'true' }} && models_only_arg='--models-only'
-        ${{ inputs.skip-cert-verification == 'true' }} && verify_cert_arg='--skip-cert-verification'
-        ${{ inputs.exclude != '' }} && exclude_arg='--exclude ${{ inputs.exclude }}'
+        args=(
+          --api-token "${{ inputs.api-token }}"
+          --webserver "${{ inputs.webserver }}"
+          --branch "${{ inputs.branch }}"
+        )
+        [[ -n "${{ inputs.namespace }}" ]] && args+=(--namespace "${{ inputs.namespace }}")
+        [[ "${{ inputs.allow-model-deletion }}" == 'true' ]] && args+=(--allow-model-deletion)
+        [[ "${{ inputs.allow-deployment-deletion }}" == 'true' ]] && args+=(--allow-deployment-deletion)
+        [[ "${{ inputs.models-only }}" == 'true' ]] && args+=(--models-only)
+        [[ "${{ inputs.skip-cert-verification }}" == 'true' ]] && args+=(--skip-cert-verification)
+        [[ -n "${{ inputs.exclude }}" ]] && args+=(--exclude "${{ inputs.exclude }}")
 
-        python ${GITHUB_ACTION_PATH}/src/main.py \
-          --api-token ${{ inputs.api-token }} \
-          --webserver ${{ inputs.webserver }} \
-          --branch ${{ inputs.branch }} \
-          ${namespace_arg} \
-          ${allow_model_deletion_arg} \
-          ${allow_deployment_deletion_arg} \
-          ${models_only_arg} \
-          ${verify_cert_arg} \
-          ${exclude_arg}
+        python ${GITHUB_ACTION_PATH}/src/main.py "${args[@]}"
       shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,8 @@ force_single_line = "True"
 [tool.pylint.'BASIC']
 good-names = ["ex", "fd"]
 
+[tool.pylint.'FORMAT']
+max-module-lines = 1200
+
 [tool.pylint.'MESSAGES CONTROL']
 disable = ["too-many-arguments", "too-many-positional-arguments"]

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -1388,7 +1388,7 @@ class DrClient:
             )
         model_package = response.json()
         try:
-            self._wait_for_async_resolution(
+            location = self._wait_for_async_resolution(
                 response.headers["Location"], max_wait=self.DEPLOYMENT_CREATE_MAX_WAIT_SEC
             )
         except HttpRequesterException as ex:
@@ -1398,7 +1398,8 @@ class DrClient:
                 f"Model package id: {model_package['id']}, "
                 f"Exception: {str(ex)}."
             ) from ex
-        return model_package
+        response = self._http_requester.get(location, raw=True)
+        return response.json()
 
     def _create_deployment_from_model_package(self, model_package, deployment_info):
         label = deployment_info.get_settings_value(DeploymentSchema.LABEL_KEY)

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -70,6 +70,16 @@ class DrClient:
     REGISTERED_MODELS_LIST_ROUTE = "registeredModels/"
     REGISTERED_MODEL_ROUTE = "registeredModels/{registered_model_id}/"
     REGISTERED_MODELS_VERSIONS_ROUTE = "registeredModels/{registered_model_id}/versions/"
+    CREDENTIALS_ROUTE = "credentials/"
+    CATALOG_ITEMS_ROUTE = "catalogItems/"
+    DATASET_ROUTE = "datasets/{dataset_id}/"
+    DATASET_FROM_FILE_ROUTE = "datasets/fromFile/"
+    COMPLIANCE_DOCS_INITIALIZATION_ROUTE = (
+        "modelComplianceDocsInitializations/{registered_model_version_id}"
+    )
+    AUTOMATED_DOCUMENTS_ROUTE = "automatedDocuments/"
+    KEY_VALUES_ROUTE = "keyValues/"
+    KEY_VALUE_ROUTE = "keyValues/{key_value_id}/"
 
     DEFAULT_MAX_WAIT_SEC = 600
 
@@ -508,22 +518,22 @@ class DrClient:
         registered_model_id = registered_model["id"] if registered_model else None
         if registered_model_id:
             existing_registered_versions = self._get_registered_model_versions(registered_model_id)
-            existing_version_id = next(
+            existing_version = next(
                 (
-                    v["id"]
+                    v
                     for v in existing_registered_versions
                     if v["modelId"] == custom_model_version_id
                 ),
                 None,
             )
-            if existing_version_id:
+            if existing_version:
                 logger.info(
                     "Custom model version is already registered. Registered model name: %s, "
                     "custom model version id: %s",
                     registered_model_name,
                     custom_model_version_id,
                 )
-                return existing_version_id
+                return existing_version
             registered_model_name = None
 
         model_package = self.create_model_package_from_custom_model_version(
@@ -532,7 +542,7 @@ class DrClient:
             registered_model_id,
         )
 
-        return model_package["id"]
+        return model_package
 
     def update_registered_model(self, registered_model_name, description, is_global):
         """
@@ -659,6 +669,22 @@ class DrClient:
         )
         if egress_network_policy:
             payload.append(("networkEgressPolicy", str(egress_network_policy)))
+
+        resource_bundle_id = model_info.get_value(
+            ModelSchema.VERSION_KEY, ModelSchema.RESOURCE_BUNDLE_ID
+        )
+        if resource_bundle_id:
+            payload.append(("resourceBundleId", resource_bundle_id))
+
+        runtime_parameters = model_info.get_value(
+            ModelSchema.VERSION_KEY, ModelSchema.RUNTIME_PARAMETER_VALUES_KEY
+        )
+        if runtime_parameters:
+            payload_params = [
+                {"fieldName": param["name"], "type": param["type"], "value": param["value"]}
+                for param in runtime_parameters
+            ]
+            payload.append(("runtimeParameterValues", json.dumps(payload_params)))
 
         return payload, file_objs
 
@@ -2226,3 +2252,168 @@ class DrClient:
 
         payload = {"searchFor": search_for} if search_for else None
         return self._paginated_fetch(self.ENVIRONMENT_DROP_IN_ROUTE, json=payload)
+
+    def fetch_credentials(self):
+        return self._paginated_fetch(self.CREDENTIALS_ROUTE)
+
+    def fetch_catalog_items(self, search_for=None):
+        params = {"searchFor": search_for} if search_for else None
+        return self._paginated_fetch(self.CATALOG_ITEMS_ROUTE, params=params)
+
+    def create_dataset_from_file(self, file):
+        with open(file, "rb") as fd:
+            payload = {"file": (str(file), fd)}
+
+            mp_encoder = MultipartEncoder(fields=payload)
+            headers = {"Content-Type": mp_encoder.content_type}
+
+            response = self._http_requester.post(
+                self.DATASET_FROM_FILE_ROUTE, data=mp_encoder, headers=headers
+            )
+
+        if response.status_code != 202:
+            raise DataRobotClientError(
+                "Failed to create dataset. "
+                f"Response status: {response.status_code} "
+                f"Response body: {response.text}",
+                code=response.status_code,
+            )
+        location = self._wait_for_async_resolution(response.headers["Location"])
+        response = self._http_requester.get(location, raw=True)
+        return response.json()
+
+    def update_dataset(self, dataset_id, name):
+        payload = {"name": name}
+
+        response = self._http_requester.patch(
+            self.DATASET_ROUTE.format(dataset_id=dataset_id),
+            json=payload,
+        )
+        if response.status_code != 200:
+            raise DataRobotClientError(
+                "Failed to update dataset properties "
+                f"Dataset id: {dataset_id}, "
+                f"Response status: {response.status_code}, "
+                f"Response body: {response.text}",
+                code=response.status_code,
+            )
+        return response.json()
+
+    def fetch_compliance_docs_initialization(self, registered_model_version_id):
+        response = self._http_requester.get(
+            self.COMPLIANCE_DOCS_INITIALIZATION_ROUTE.format(
+                registered_model_version_id=registered_model_version_id
+            )
+        )
+        return response.json()
+
+    def fetch_key_values(self, registered_model_version_id):
+        return self._paginated_fetch(
+            self.KEY_VALUES_ROUTE,
+            params={"entityId": registered_model_version_id, "entityType": "modelPackage"},
+        )
+
+    def create_key_value(self, registered_model_version_id, name, category, value, value_type):
+        payload = self._create_key_value_payload(
+            category, name, registered_model_version_id, value, value_type
+        )
+
+        response = self._http_requester.post(self.KEY_VALUES_ROUTE, json=payload)
+        if response.status_code != 201:
+            raise DataRobotClientError(
+                "Failed to create key-value. "
+                f"Response status: {response.status_code} "
+                f"Response body: {response.text}",
+                code=response.status_code,
+            )
+        return response.json()
+
+    def update_key_value(
+        self,
+        key_value_id,
+        registered_model_version_id,
+        name,
+        category,
+        value,
+        value_type,
+    ):
+        payload = self._create_key_value_payload(
+            category, name, registered_model_version_id, value, value_type
+        )
+        response = self._http_requester.patch(
+            self.KEY_VALUE_ROUTE.format(key_value_id=key_value_id), json=payload
+        )
+        if response.status_code != 200:
+            raise DataRobotClientError(
+                "Failed to create/update key-value. "
+                f"Response status: {response.status_code} "
+                f"Response body: {response.text}",
+                code=response.status_code,
+            )
+        return response.json()
+
+    def delete_key_value(self, key_value_id):
+        response = self._http_requester.delete(
+            self.KEY_VALUE_ROUTE.format(key_value_id=key_value_id)
+        )
+        if response.status_code != 204:
+            raise DataRobotClientError(
+                "Failed to delete key-value. "
+                f"Response status: {response.status_code} "
+                f"Response body: {response.text}",
+                code=response.status_code,
+            )
+
+    def perform_compliance_docs_initialization(self, registered_model_version_id):
+        response = self._http_requester.post(
+            self.COMPLIANCE_DOCS_INITIALIZATION_ROUTE.format(
+                registered_model_version_id=registered_model_version_id
+            )
+        )
+
+        if response.status_code != 202:
+            raise DataRobotClientError(
+                "Failed to initialize compliance docs. "
+                f"Response status: {response.status_code} "
+                f"Response body: {response.text}",
+                code=response.status_code,
+            )
+        location = self._wait_for_async_resolution(response.headers["Location"], max_wait=30 * 60)
+        response = self._http_requester.get(location, raw=True)
+        return response.json()
+
+    def create_compliance_docs(self, registered_model_version_id):
+        payload = {
+            "documentType": "MODEL_COMPLIANCE",
+            "entityId": registered_model_version_id,
+            "outputFormat": "docx",
+        }
+
+        response = self._http_requester.post(self.AUTOMATED_DOCUMENTS_ROUTE, json=payload)
+
+        if response.status_code != 202:
+            raise DataRobotClientError(
+                "Failed to create compliance docs. "
+                f"Response status: {response.status_code} "
+                f"Response body: {response.text}",
+                code=response.status_code,
+            )
+        self._wait_for_async_resolution(response.headers["Location"])
+
+    def _create_key_value_payload(
+        self, category, name, registered_model_version_id, value, value_type
+    ):
+        payload = {
+            "entityId": registered_model_version_id,
+            "entityType": "modelPackage",
+            "name": name,
+            "category": category,
+            "valueType": value_type,
+        }
+        if value_type == "boolean":
+            payload["booleanValue"] = value
+        elif value_type == "numeric":
+            payload["numericValue"] = value
+        else:
+            payload["value"] = value
+        return payload

--- a/src/dr_client.py
+++ b/src/dr_client.py
@@ -2254,13 +2254,19 @@ class DrClient:
         return self._paginated_fetch(self.ENVIRONMENT_DROP_IN_ROUTE, json=payload)
 
     def fetch_credentials(self):
+        """Fetch all credentials stored in DataRobot."""
+
         return self._paginated_fetch(self.CREDENTIALS_ROUTE)
 
     def fetch_catalog_items(self, search_for=None):
+        """Fetch AI catalog items, optionally filtered by name via search_for."""
+
         params = {"searchFor": search_for} if search_for else None
         return self._paginated_fetch(self.CATALOG_ITEMS_ROUTE, params=params)
 
     def create_dataset_from_file(self, file):
+        """Upload a local file to the AI catalog as a new dataset."""
+
         with open(file, "rb") as fd:
             payload = {"file": (str(file), fd)}
 
@@ -2283,6 +2289,8 @@ class DrClient:
         return response.json()
 
     def update_dataset(self, dataset_id, name):
+        """Rename an existing AI catalog dataset."""
+
         payload = {"name": name}
 
         response = self._http_requester.patch(
@@ -2300,6 +2308,8 @@ class DrClient:
         return response.json()
 
     def fetch_compliance_docs_initialization(self, registered_model_version_id):
+        """Fetch the compliance docs initialization status for a registered model version."""
+
         response = self._http_requester.get(
             self.COMPLIANCE_DOCS_INITIALIZATION_ROUTE.format(
                 registered_model_version_id=registered_model_version_id
@@ -2308,12 +2318,16 @@ class DrClient:
         return response.json()
 
     def fetch_key_values(self, registered_model_version_id):
+        """Fetch all key-values attached to a registered model version."""
+
         return self._paginated_fetch(
             self.KEY_VALUES_ROUTE,
             params={"entityId": registered_model_version_id, "entityType": "modelPackage"},
         )
 
     def create_key_value(self, registered_model_version_id, name, category, value, value_type):
+        """Create a new key-value on a registered model version."""
+
         payload = self._create_key_value_payload(
             category, name, registered_model_version_id, value, value_type
         )
@@ -2337,6 +2351,8 @@ class DrClient:
         value,
         value_type,
     ):
+        """Update an existing key-value on a registered model version."""
+
         payload = self._create_key_value_payload(
             category, name, registered_model_version_id, value, value_type
         )
@@ -2353,6 +2369,8 @@ class DrClient:
         return response.json()
 
     def delete_key_value(self, key_value_id):
+        """Delete a key-value by id."""
+
         response = self._http_requester.delete(
             self.KEY_VALUE_ROUTE.format(key_value_id=key_value_id)
         )
@@ -2365,6 +2383,8 @@ class DrClient:
             )
 
     def perform_compliance_docs_initialization(self, registered_model_version_id):
+        """Trigger compliance docs initialization for a registered model version."""
+
         response = self._http_requester.post(
             self.COMPLIANCE_DOCS_INITIALIZATION_ROUTE.format(
                 registered_model_version_id=registered_model_version_id
@@ -2383,6 +2403,8 @@ class DrClient:
         return response.json()
 
     def create_compliance_docs(self, registered_model_version_id):
+        """Generate a compliance docs document for a registered model version."""
+
         payload = {
             "documentType": "MODEL_COMPLIANCE",
             "entityId": registered_model_version_id,

--- a/src/main.py
+++ b/src/main.py
@@ -50,6 +50,10 @@ def argparse_options(args=None):
         "--namespace", help="It is used to group and isolate models and deployments."
     )
     parser.add_argument(
+        "--exclude",
+        help="Regex pattern to exclude YAML files from being processed. Can match any part of the file path."
+    )
+    parser.add_argument(
         "--allow-model-deletion",
         action="store_true",
         help="Whether to detect local deleted model definitions and consequently delete them in "

--- a/src/main.py
+++ b/src/main.py
@@ -51,7 +51,8 @@ def argparse_options(args=None):
     )
     parser.add_argument(
         "--exclude",
-        help="Regex pattern to exclude YAML files from being processed. Can match any part of the file path.",
+        help="Regex pattern to exclude YAML files from being processed. "
+        "Can match any part of the file path.",
     )
     parser.add_argument(
         "--allow-model-deletion",

--- a/src/main.py
+++ b/src/main.py
@@ -51,7 +51,7 @@ def argparse_options(args=None):
     )
     parser.add_argument(
         "--exclude",
-        help="Regex pattern to exclude YAML files from being processed. Can match any part of the file path."
+        help="Regex pattern to exclude YAML files from being processed. Can match any part of the file path.",
     )
     parser.add_argument(
         "--allow-model-deletion",

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -371,8 +371,8 @@ class ModelController(ControllerBase):
                 param["value"] = next(
                     (c["credentialId"] for c in credentials if c["name"] == param["value"])
                 )
-            except StopIteration:
-                raise ValueError(f"Failed to find credential with name {param['value']}.")
+            except StopIteration as exc:
+                raise ValueError(f"Failed to find credential with name {param['value']}.") from exc
 
         model_info.set_value(
             ModelSchema.VERSION_KEY,
@@ -393,11 +393,11 @@ class ModelController(ControllerBase):
         if not dataset_file_path.exists():
             raise ValueError(f"Dataset file: '{dataset_file_path}' does not exist.")
 
-        BUF_SIZE = 65536  # TODO: Put somewhere else
+        buf_size = 65536  # TODO: Put somewhere else
         sha1 = hashlib.sha1()
         with open(dataset_file_path, "rb") as f:
             while True:
-                data = f.read(BUF_SIZE)
+                data = f.read(buf_size)
                 if not data:
                     break
                 sha1.update(data)
@@ -409,7 +409,9 @@ class ModelController(ControllerBase):
         items = self._dr_client.fetch_catalog_items(search_for=catalog_item_name)
         matching_items = [item for item in items if item["catalogName"] == catalog_item_name]
         if len(matching_items) > 1:
-            raise Exception(f"Found multiple items in catalog with name: '{catalog_item_name}'")
+            raise UnexpectedResult(
+                f"Found multiple items in catalog with name: '{catalog_item_name}'"
+            )
 
         if not matching_items:
             dataset = self._dr_client.create_dataset_from_file(dataset_file_path)
@@ -837,15 +839,14 @@ class ModelController(ControllerBase):
                     and local_key_value["value_type"] == match["valueType"]
                 ):
                     continue
-                else:
-                    self._dr_client.update_key_value(
-                        match["id"],
-                        registered_model_version["id"],
-                        local_key_value["name"],
-                        local_key_value["category"],
-                        local_key_value["value"],
-                        local_key_value["value_type"],
-                    )
+                self._dr_client.update_key_value(
+                    match["id"],
+                    registered_model_version["id"],
+                    local_key_value["name"],
+                    local_key_value["category"],
+                    local_key_value["value"],
+                    local_key_value["value_type"],
+                )
             else:
                 self._dr_client.create_key_value(
                     registered_model_version["id"],

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -40,6 +40,9 @@ from schema_validator import ModelSchema
 
 logger = logging.getLogger()
 
+# Chunk size used when hashing a training dataset file to compute its checksum.
+DATASET_FILE_HASH_BUF_SIZE = 65536
+
 
 class ControllerBase(ABC):
     """
@@ -393,11 +396,10 @@ class ModelController(ControllerBase):
         if not dataset_file_path.exists():
             raise ValueError(f"Dataset file: '{dataset_file_path}' does not exist.")
 
-        buf_size = 65536  # TODO: Put somewhere else
         sha1 = hashlib.sha1()
         with open(dataset_file_path, "rb") as f:
             while True:
-                data = f.read(buf_size)
+                data = f.read(DATASET_FILE_HASH_BUF_SIZE)
                 if not data:
                     break
                 sha1.update(data)

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -8,7 +8,8 @@ This module controls and coordinate between local model definitions and DataRobo
 In highlights, it scans and loads model definitions from the local source tree, perform
 validations and then applies actions in DataRobot.
 """
-
+import hashlib
+import json
 import logging
 import os
 import re
@@ -58,6 +59,7 @@ class ControllerBase(ABC):
             verify_cert=not self.options.skip_cert_verification,
         )
         self._metrics = Metrics(self._label())
+        self._exclude_pattern = re.compile(options.exclude) if getattr(options, "exclude", None) else None
         logger.info(
             "GITHUB_EVENT_NAME: %s, GITHUB_SHA: %s, GITHUB_REPOSITORY: %s, GITHUB_REF_NAME: %s",
             GitHubEnv.event_name(),
@@ -81,9 +83,20 @@ class ControllerBase(ABC):
     def _next_yaml_content_in_repo(self):
         yaml_files = glob(f"{self._workspace_path}/**/*.yaml", recursive=True)
         yaml_files.extend(glob(f"{self._workspace_path}/**/*.yml", recursive=True))
+        
         for yaml_path in yaml_files:
+            # Skip files that match the exclude pattern
+            if self._exclude_pattern and self._exclude_pattern.search(yaml_path):
+                logger.debug("Excluding YAML file matching pattern: %s", yaml_path)
+                continue
+                
             with open(yaml_path, encoding="utf-8") as fd:
-                yaml_content = yaml.safe_load(fd)
+                try:
+                    yaml_content = yaml.safe_load(fd)
+                except yaml.YAMLError:
+                    logger.warning("Failed to parse yaml file: %s", yaml_path, exc_info=True)
+                    continue
+                    
                 if not yaml_content:
                     logger.warning("Detected an invalid or empty yaml file: %s", yaml_path)
                 else:
@@ -306,8 +319,83 @@ class ModelController(ControllerBase):
                     )
                 self._set_datarobot_custom_model(user_provided_id, custom_model, latest_version)
 
+    @staticmethod
+    def _replace_runtime_param_credentials(model_info, credentials):
+        """Replace credential runtime parameter name with id so that it can be compared with the id
+        present in the serverside runtime parameter value."""
+        model_parameters = model_info.get_value(
+            ModelSchema.VERSION_KEY, ModelSchema.RUNTIME_PARAMETER_VALUES_KEY
+        )
+        if not model_parameters:
+            return model_info
+
+        for param in model_parameters:
+            if param["type"] != "credential":
+                continue
+
+            try:
+                param["value"] = next(
+                    (c["credentialId"] for c in credentials if c["name"] == param["value"])
+                )
+            except StopIteration:
+                raise ValueError(f"Failed to find credential with name {param['value']}.")
+
+        model_info.set_value(
+            ModelSchema.VERSION_KEY,
+            ModelSchema.RUNTIME_PARAMETER_VALUES_KEY,
+            value=model_parameters,
+        )
+
+        return model_info
+
+    def _populate_dataset_id_from_file(self, model_info):
+        dataset_file = model_info.get_value(
+            ModelSchema.VERSION_KEY, ModelSchema.TRAINING_DATASET_FILE_KEY
+        )
+        if not dataset_file:
+            return model_info
+
+        dataset_file_path = model_info.model_path / dataset_file
+        if not dataset_file_path.exists():
+            raise ValueError(f"Dataset file: '{dataset_file_path}' does not exist.")
+
+        BUF_SIZE = 65536  # TODO: Put somewhere else
+        sha1 = hashlib.sha1()
+        with open(dataset_file_path, "rb") as f:
+            while True:
+                data = f.read(BUF_SIZE)
+                if not data:
+                    break
+                sha1.update(data)
+
+        checksum = sha1.hexdigest()
+
+        catalog_item_name = f"{model_info.user_provided_id}_{dataset_file}_{checksum}"
+
+        items = self._dr_client.fetch_catalog_items(search_for=catalog_item_name)
+        matching_items = [item for item in items if item["catalogName"] == catalog_item_name]
+        if len(matching_items) > 1:
+            raise Exception(f"Found multiple items in catalog with name: '{catalog_item_name}'")
+
+        if not matching_items:
+            dataset = self._dr_client.create_dataset_from_file(dataset_file_path)
+            dataset_id = dataset["datasetId"]
+            self._dr_client.update_dataset(dataset_id, catalog_item_name)
+        else:
+            dataset_id = matching_items[0]["id"]
+
+        model_info.set_value(
+            ModelSchema.VERSION_KEY, ModelSchema.TRAINING_DATASET_ID_KEY, value=dataset_id
+        )
+
+        return model_info
+
     def _set_datarobot_custom_model(self, user_provided_id, custom_model, latest_version=None):
+        logger.debug("Custom model: %s", json.dumps(custom_model))
+        logger.debug("Latest version: %s", json.dumps(latest_version))
         datarobot_model = DataRobotModel(model=custom_model, latest_version=latest_version)
+        logger.debug("DataRobot model: %s", json.dumps(datarobot_model.__dict__))
+        logger.debug("User-provided id: %s", user_provided_id)
         self.datarobot_models[user_provided_id] = datarobot_model
         self._datarobot_models_by_id[custom_model["id"]] = datarobot_model
         logger.debug(
@@ -362,10 +450,12 @@ class ModelController(ControllerBase):
 
     def _get_latest_model_version_git_commit_ancestor(self, model_info):
         latest_version = self.datarobot_models[model_info.user_provided_id].latest_version
+        logger.debug("Latest version queried: %s", json.dumps(latest_version))
         git_model_version = latest_version.get("gitModelVersion")
         if not git_model_version:
             # Either the model has never provisioned or the user created a version with a non
             # GitHub action client.
+            logger.debug("No git model version found")
             return False
 
         return git_model_version[self.ancestor_attribute_ref(git_model_version)]
@@ -387,10 +477,12 @@ class ModelController(ControllerBase):
         str,
             The DataRobot public API attribute name.
         """
-
+        logger.debug("GIT model version: %s", json.dumps(git_model_version))
         latest_ref_name = git_model_version["refName"]
         if GitHubEnv.is_pull_request() and GitHubEnv.ref_name() == latest_ref_name:
+            logger.debug("Getting pull request commit sha")
             return "pullRequestCommitSha"
+        logger.debug("Getting main branch commit sha")
         return "mainBranchCommitSha"
 
     def _lookup_affected_models(self):
@@ -414,7 +506,11 @@ class ModelController(ControllerBase):
             # The model has not yet been created or
             return
 
-        from_commit_sha = self._get_git_commit_ancestor(model_info)
+        latest_version = self.datarobot_models[model_info.user_provided_id].latest_version
+        if latest_version:
+            from_commit_sha = self._get_latest_model_version_git_commit_ancestor(model_info)
+        else:
+            from_commit_sha = self._get_git_commit_ancestor(model_info)
         if not from_commit_sha:
             raise UnexpectedResult(
                 "Unexpected None ancestor commit sha, "
@@ -501,6 +597,7 @@ class ModelController(ControllerBase):
             return
 
         from_commit_sha = self._get_latest_model_version_git_commit_ancestor(model_info)
+        logger.debug("Got commit SHA: %s", from_commit_sha)
         if not from_commit_sha:
             raise UnexpectedResult(
                 "Unexpected None ancestor commit sha, "
@@ -576,12 +673,17 @@ class ModelController(ControllerBase):
     def handle_model_changes(self):
         """Apply changes in DataRobot for models that were affected by the current commit."""
 
+        credentials = self._dr_client.fetch_credentials()
+
         for user_provided_id, model_info in self.models_info.items():
             already_exists = user_provided_id in self.datarobot_models
             custom_model = self.datarobot_models[user_provided_id].model if already_exists else None
             previous_latest_version = latest_version = (
                 self.datarobot_models[user_provided_id].latest_version if already_exists else None
             )
+
+            model_info = self._replace_runtime_param_credentials(model_info, credentials)
+            model_info = self._populate_dataset_id_from_file(model_info)
 
             if model_info.is_affected_by_commit(latest_version):
                 logger.info("Model '%s' is affected by commit.", model_info.model_path)
@@ -631,15 +733,91 @@ class ModelController(ControllerBase):
                     custom_model["id"], latest_version["id"], model_info
                 )
 
-            if model_info.should_register_model:
-                self._dr_client.create_or_update_registered_model(
-                    latest_version["id"], model_info.registered_model_name
+            self._handle_model_registry(model_info, latest_version)
+
+    def _handle_model_registry(self, model_info, latest_version):
+        if not model_info.should_register_model:
+            return
+
+        registered_model_version = self._dr_client.create_or_update_registered_model(
+            latest_version["id"], model_info.registered_model_name
+        )
+        self._dr_client.update_registered_model(
+            model_info.registered_model_name,
+            model_info.registered_model_description,
+            model_info.registered_model_global,
+        )
+
+        self._handle_compliance_docs(model_info, registered_model_version)
+        self._handle_key_values(model_info, registered_model_version)
+
+    def _handle_compliance_docs(self, model_info, registered_model_version):
+        if not model_info.get_value(
+            ModelSchema.MODEL_REGISTRY_KEY, ModelSchema.COMPLIANCE_DOCS_KEY
+        ):
+            return
+
+        docs_count = registered_model_version["complianceDocsCount"]
+        if docs_count is not None and docs_count > 0:
+            logger.debug("Compliance docs already present. Model: %s", model_info.user_provided_id)
+            return
+
+        logger.info("Generating compliance docs. Model: %s", model_info.user_provided_id)
+        compliance_docs_initialization = self._dr_client.fetch_compliance_docs_initialization(
+            registered_model_version["id"]
+        )
+        if not compliance_docs_initialization["initialized"]:
+            self._dr_client.perform_compliance_docs_initialization(registered_model_version["id"])
+
+        self._dr_client.create_compliance_docs(registered_model_version["id"])
+
+    def _handle_key_values(self, model_info, registered_model_version):
+        local_key_values = model_info.get_value(
+            ModelSchema.MODEL_REGISTRY_KEY, ModelSchema.VERSION_KEY, ModelSchema.KEY_VALUES_KEY
+        )
+        if not local_key_values:
+            return
+
+        server_key_values = self._dr_client.fetch_key_values(registered_model_version["id"])
+
+        for local_key_value in local_key_values:
+            match = next(
+                (kv for kv in server_key_values if kv["name"] == local_key_value["name"]), None
+            )
+
+            if match:
+                if (
+                    str(local_key_value["value"]) == match["value"]
+                    and local_key_value["category"] == match["category"]
+                ):
+                    continue
+                else:
+                    self._dr_client.update_key_value(
+                        match["id"],
+                        registered_model_version["id"],
+                        local_key_value["name"],
+                        local_key_value["category"],
+                        local_key_value["value"],
+                        local_key_value["value_type"],
+                    )
+            else:
+                self._dr_client.create_key_value(
+                    registered_model_version["id"],
+                    local_key_value["name"],
+                    local_key_value["category"],
+                    local_key_value["value"],
+                    local_key_value["value_type"],
                 )
-                self._dr_client.update_registered_model(
-                    model_info.registered_model_name,
-                    model_info.registered_model_description,
-                    model_info.registered_model_global,
-                )
+
+        for server_key_value in server_key_values:
+            if server_key_value["creatorName"] == "system":
+                continue
+
+            match = next(
+                (kv for kv in local_key_values if kv["name"] == server_key_value["name"]), None
+            )
+            if not match:
+                self._dr_client.delete_key_value(server_key_value["id"])
 
     @staticmethod
     def _was_new_version_created(previous_latest_version, latest_version):
@@ -853,10 +1031,11 @@ class ModelController(ControllerBase):
         if missing_locally_id_to_git_id:
             if not self.options.allow_model_deletion:
                 missing_user_provided_ids = list(missing_locally_id_to_git_id.values())
-                raise IllegalModelDeletion(
+                logger.info(
                     "Model deletion was configured as not being allowed. "
                     f"The missing models in the local source tree are: {missing_user_provided_ids}"
                 )
+                return
 
             model_ids_to_fetch = list(missing_locally_id_to_git_id.keys())
             deployments = self._dr_client.fetch_custom_model_deployments(model_ids_to_fetch)

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -59,7 +59,10 @@ class ControllerBase(ABC):
             verify_cert=not self.options.skip_cert_verification,
         )
         self._metrics = Metrics(self._label())
-        self._exclude_pattern = re.compile(options.exclude) if getattr(options, "exclude", None) else None
+        self._exclude_pattern = (
+            re.compile(options.exclude) if getattr(options, "exclude", None) else None
+        )
+        self._excluded_user_provided_ids = set()
         logger.info(
             "GITHUB_EVENT_NAME: %s, GITHUB_SHA: %s, GITHUB_REPOSITORY: %s, GITHUB_REF_NAME: %s",
             GitHubEnv.event_name(),
@@ -83,24 +86,55 @@ class ControllerBase(ABC):
     def _next_yaml_content_in_repo(self):
         yaml_files = glob(f"{self._workspace_path}/**/*.yaml", recursive=True)
         yaml_files.extend(glob(f"{self._workspace_path}/**/*.yml", recursive=True))
-        
+
         for yaml_path in yaml_files:
-            # Skip files that match the exclude pattern
+            # Skip files that match the exclude pattern. We still make a best-effort attempt to
+            # record the excluded model's user_provided_id (without full schema validation, since
+            # exclusion is also used for files that don't validate) so handle_deleted_models can
+            # tell "intentionally excluded" apart from "actually deleted" and not raise/delete for
+            # models that are simply not being scanned right now.
             if self._exclude_pattern and self._exclude_pattern.search(yaml_path):
                 logger.debug("Excluding YAML file matching pattern: %s", yaml_path)
+                self._record_excluded_user_provided_ids(yaml_path)
                 continue
-                
+
             with open(yaml_path, encoding="utf-8") as fd:
-                try:
-                    yaml_content = yaml.safe_load(fd)
-                except yaml.YAMLError:
-                    logger.warning("Failed to parse yaml file: %s", yaml_path, exc_info=True)
-                    continue
-                    
+                yaml_content = yaml.safe_load(fd)
                 if not yaml_content:
                     logger.warning("Detected an invalid or empty yaml file: %s", yaml_path)
                 else:
                     yield yaml_path, yaml_content
+
+    def _record_excluded_user_provided_ids(self, yaml_path):
+        """Best-effort extraction of user_provided_id(s) from an excluded YAML file.
+
+        This does not run schema validation, since exclusion is also used for files that
+        wouldn't validate. Any failure here is swallowed - worst case, this specific excluded
+        model is not recognized and deletion-safety treats it like any other excluded file for
+        which the id couldn't be determined.
+        """
+
+        try:
+            with open(yaml_path, encoding="utf-8") as fd:
+                yaml_content = yaml.safe_load(fd)
+        except (yaml.YAMLError, OSError):
+            return
+
+        if not isinstance(yaml_content, dict):
+            return
+
+        if ModelSchema.MULTI_MODELS_KEY in yaml_content:
+            for model_entry in yaml_content.get(ModelSchema.MULTI_MODELS_KEY) or []:
+                if not isinstance(model_entry, dict):
+                    continue
+                model_metadata = model_entry.get(ModelSchema.MODEL_ENTRY_META_KEY) or {}
+                user_provided_id = model_metadata.get(ModelSchema.MODEL_ID_KEY)
+                if user_provided_id:
+                    self._excluded_user_provided_ids.add(user_provided_id)
+        else:
+            user_provided_id = yaml_content.get(ModelSchema.MODEL_ID_KEY)
+            if user_provided_id:
+                self._excluded_user_provided_ids.add(user_provided_id)
 
     @staticmethod
     def _make_directory_pattern_recursive(pattern):
@@ -509,13 +543,24 @@ class ModelController(ControllerBase):
         latest_version = self.datarobot_models[model_info.user_provided_id].latest_version
         if latest_version:
             from_commit_sha = self._get_latest_model_version_git_commit_ancestor(model_info)
+            if not from_commit_sha:
+                # The latest version has no git model version (e.g. created via the UI or a
+                # non-action client). We cannot compute a settings diff without an ancestor
+                # commit - mirrors how version handling elsewhere already treats a missing
+                # ancestor as "upload everything" rather than failing.
+                logger.debug(
+                    "No git commit ancestor found for the latest version of model %s; "
+                    "skipping settings-change detection for this model.",
+                    model_info.user_provided_id,
+                )
+                return
         else:
             from_commit_sha = self._get_git_commit_ancestor(model_info)
-        if not from_commit_sha:
-            raise UnexpectedResult(
-                "Unexpected None ancestor commit sha, "
-                f"model_git_id: {model_info.user_provided_id}"
-            )
+            if not from_commit_sha:
+                raise UnexpectedResult(
+                    "Unexpected None ancestor commit sha, "
+                    f"model_git_id: {model_info.user_provided_id}"
+                )
         changed_files, deleted_files = self._repo.find_changed_files(
             GitHubEnv.github_sha(), from_commit_sha
         )
@@ -787,8 +832,9 @@ class ModelController(ControllerBase):
 
             if match:
                 if (
-                    str(local_key_value["value"]) == match["value"]
+                    self._key_value_matches_server(local_key_value, match)
                     and local_key_value["category"] == match["category"]
+                    and local_key_value["value_type"] == match["valueType"]
                 ):
                     continue
                 else:
@@ -818,6 +864,29 @@ class ModelController(ControllerBase):
             )
             if not match:
                 self._dr_client.delete_key_value(server_key_value["id"])
+
+    @staticmethod
+    def _key_value_matches_server(local_key_value, server_key_value):
+        """
+        Compare a local key-value's value against the server's, by type.
+
+        The server only stores a meaningful string in "value" for string/url/credential
+        types; for "boolean" it's the Python str() of the boolean ("True"/"False"), and for
+        "numeric" the "value" field is always empty - the real number lives in
+        "numericValue" instead. Comparing "value" directly for booleans/numerics either
+        risks a string-format mismatch or - for numerics - always mismatches against an
+        empty string, causing needless re-patching on every run.
+        """
+
+        value_type = local_key_value["value_type"]
+        if value_type == "numeric":
+            try:
+                return float(local_key_value["value"]) == server_key_value.get("numericValue")
+            except (TypeError, ValueError):
+                return False
+        if value_type == "boolean":
+            return bool(local_key_value["value"]) == server_key_value.get("booleanValue")
+        return str(local_key_value["value"]) == server_key_value["value"]
 
     @staticmethod
     def _was_new_version_created(previous_latest_version, latest_version):
@@ -1025,17 +1094,24 @@ class ModelController(ControllerBase):
 
         missing_locally_id_to_git_id = {}
         for user_provided_id, datarobot_model in self.datarobot_models.items():
-            if user_provided_id not in self.models_info:
-                missing_locally_id_to_git_id[datarobot_model.model["id"]] = user_provided_id
+            if user_provided_id in self.models_info:
+                continue
+            if user_provided_id in self._excluded_user_provided_ids:
+                logger.debug(
+                    "Model %s is not in the local source tree because it's excluded "
+                    "(--exclude), not because it was deleted. Skipping deletion handling.",
+                    user_provided_id,
+                )
+                continue
+            missing_locally_id_to_git_id[datarobot_model.model["id"]] = user_provided_id
 
         if missing_locally_id_to_git_id:
             if not self.options.allow_model_deletion:
                 missing_user_provided_ids = list(missing_locally_id_to_git_id.values())
-                logger.info(
+                raise IllegalModelDeletion(
                     "Model deletion was configured as not being allowed. "
                     f"The missing models in the local source tree are: {missing_user_provided_ids}"
                 )
-                return
 
             model_ids_to_fetch = list(missing_locally_id_to_git_id.keys())
             deployments = self._dr_client.fetch_custom_model_deployments(model_ids_to_fetch)

--- a/src/model_info.py
+++ b/src/model_info.py
@@ -315,6 +315,7 @@ class ModelInfo(InfoBase):
             (ModelSchema.MEMORY_KEY, "maximumMemory"),
             (ModelSchema.REPLICAS_KEY, "replicas"),
             (ModelSchema.EGRESS_NETWORK_POLICY_KEY, "networkEgressPolicy"),
+            (ModelSchema.RESOURCE_BUNDLE_ID, "resourceBundleId"),
         ):
             configured_resource = self.get_value(ModelSchema.VERSION_KEY, resource_key)
             if configured_resource and configured_resource != datarobot_latest_model_version.get(
@@ -329,6 +330,34 @@ class ModelInfo(InfoBase):
                 )
                 return True
 
+        model_parameters = self.get_value(
+            ModelSchema.VERSION_KEY, ModelSchema.RUNTIME_PARAMETER_VALUES_KEY
+        )
+        if model_parameters:
+            for param in model_parameters:
+                latest_version_param = next(
+                    (
+                        p
+                        for p in datarobot_latest_model_version["runtimeParameters"]
+                        if p["fieldName"] == param["name"]
+                    ),
+                    None,
+                )
+                if latest_version_param is None:
+                    raise ValueError(
+                        f"Model version on server does not have runtime param: '{param['name']}'"
+                    )
+
+                if param["value"] != latest_version_param["currentValue"]:
+                    logger.debug(
+                        "Need to create new version. Runtime param '%s' changed. "
+                        "Configured value: '%s'. Value on server: '%s'",
+                        param["name"],
+                        param["value"],
+                        latest_version_param["currentValue"],
+                    )
+                    return True
+
         return False
 
     def is_there_a_change_in_training_or_holdout_data_at_version_level(
@@ -340,15 +369,20 @@ class ModelInfo(InfoBase):
         configured_training_dataset = self.get_value(
             ModelSchema.VERSION_KEY, ModelSchema.TRAINING_DATASET_ID_KEY
         )
+        if configured_training_dataset is None:
+            return False
+
         if datarobot_latest_model_version is None:
             # This can happen only when the custom model is first created and still does not have
             # any associated version. A hidden assumption is that a holdout data will never be set
             # without a training data
             return configured_training_dataset is not None
 
-        latest_training_dataset = datarobot_latest_model_version.get("training_data", {}).get(
-            "dataset_id"
+        latest_training_data = datarobot_latest_model_version.get("trainingData", None)
+        latest_training_dataset = (
+            latest_training_data["datasetId"] if latest_training_data else None
         )
+
         if configured_training_dataset != latest_training_dataset:
             logger.debug("Configured training dataset != latest training dataset")
             return True
@@ -358,9 +392,12 @@ class ModelInfo(InfoBase):
             configured_holdout_dataset = self.get_value(
                 ModelSchema.VERSION_KEY, ModelSchema.TRAINING_DATASET_ID_KEY
             )
-            latest_holdout_dataset = datarobot_latest_model_version.get("holdout_data", {}).get(
-                "dataset_id"
+
+            latest_holdout_data = datarobot_latest_model_version.get("holdoutData", None)
+            latest_holdout_dataset = (
+                latest_holdout_data["datasetId"] if latest_holdout_data else None
             )
+
             if configured_holdout_dataset != latest_holdout_dataset:
                 logger.debug("Configured holdout dataset != latest holdout dataset")
                 return True

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -235,6 +235,7 @@ class ModelSchema(SharedSchema):
     # The 'PARTITIONING_COLUMN_KEY' is relevant for structured models only and is optional.
     PARTITIONING_COLUMN_KEY = "partitioning_column"
     TRAINING_DATASET_ID_KEY = "training_dataset_id"
+    TRAINING_DATASET_FILE_KEY = "training_dataset_file"
     # The 'HOLDOUT_DATASET_ID_KEY' is relevant for unstructured models only and is optional.
     HOLDOUT_DATASET_ID_KEY = "holdout_dataset_id"
 
@@ -248,6 +249,10 @@ class ModelSchema(SharedSchema):
     EGRESS_NETWORK_POLICY_KEY = "egress_network_policy"
     EGRESS_NETWORK_POLICY_NONE = "NONE"
     EGRESS_NETWORK_POLICY_PUBLIC = "PUBLIC"
+
+    RESOURCE_BUNDLE_ID = "resource_bundle_id"
+
+    RUNTIME_PARAMETER_VALUES_KEY = "runtime_parameter_values"
 
     MODEL_REPLACEMENT_REASON_KEY = "model_replacement_reason"
     MODEL_REPLACEMENT_REASON_ACCURACY = "ACCURACY"
@@ -287,6 +292,8 @@ class ModelSchema(SharedSchema):
     MODEL_NAME = "model_name"
     MODEL_DESCRIPTION = "model_description"
     GLOBAL = "global"
+    COMPLIANCE_DOCS_KEY = "compliance_docs"
+    KEY_VALUES_KEY = "key_values"
 
     MODEL_SCHEMA = Schema(
         {
@@ -329,8 +336,10 @@ class ModelSchema(SharedSchema):
                 Optional(EGRESS_NETWORK_POLICY_KEY): Or(
                     EGRESS_NETWORK_POLICY_NONE, EGRESS_NETWORK_POLICY_PUBLIC
                 ),
+                Optional(RESOURCE_BUNDLE_ID): And(str, len),
                 Optional(PARTITIONING_COLUMN_KEY): And(str, len),
                 Optional(TRAINING_DATASET_ID_KEY): And(str, ObjectId.is_valid),
+                Optional(TRAINING_DATASET_FILE_KEY): And(str, len),
                 Optional(HOLDOUT_DATASET_ID_KEY): And(str, ObjectId.is_valid),
                 Optional(MODEL_REPLACEMENT_REASON_KEY, default=MODEL_REPLACEMENT_REASON_OTHER): Or(
                     MODEL_REPLACEMENT_REASON_ACCURACY,
@@ -341,6 +350,18 @@ class ModelSchema(SharedSchema):
                     MODEL_REPLACEMENT_REASON_DEPRECATION,
                     MODEL_REPLACEMENT_REASON_OTHER,
                 ),
+                Optional(RUNTIME_PARAMETER_VALUES_KEY): [
+                    {
+                        "name": str,
+                        "type": str,
+                        "value": Or(
+                            str,
+                            bool,
+                            int,
+                            float,
+                        ),
+                    }
+                ],
             },
             Optional(TEST_KEY): {
                 # The skip attribute allows users to have the test section in their yaml file
@@ -387,6 +408,17 @@ class ModelSchema(SharedSchema):
                 Optional(MODEL_NAME): And(str, len),
                 Optional(MODEL_DESCRIPTION): And(str, len),
                 Optional(GLOBAL, default=False): bool,
+                Optional(COMPLIANCE_DOCS_KEY, default=False): bool,
+                Optional(VERSION_KEY): {
+                    Optional(KEY_VALUES_KEY): [
+                        {
+                            "name": str,
+                            "category": str,
+                            "value_type": str,
+                            "value": Or(str, int, float, bool),
+                        }
+                    ],
+                },
             },
         }
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -331,6 +331,7 @@ def options(workspace_path):
             allow_deployment_deletion=True,
             skip_cert_verification=True,
             models_only=False,
+            exclude=None,
         )
 
 

--- a/tests/unit/test_custom_inference_model.py
+++ b/tests/unit/test_custom_inference_model.py
@@ -529,6 +529,7 @@ class TestGlobPatterns:
             api_token="abc",
             skip_cert_verification=True,
             branch="master",
+            exclude=None,
         )
         with patch.object(
             ModelController, "models_info", new_callable=PropertyMock

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -1590,7 +1590,7 @@ class TestRegisteredModels:
             "custom_model_version_id", "non_existent_registered_model"
         )
 
-        assert registered_model_version == "new_registered_model_id"
+        assert registered_model_version["id"] == "new_registered_model_id"
 
     @pytest.mark.usefixtures("patch_wait_for_async_resolution")
     @responses.activate
@@ -1629,7 +1629,7 @@ class TestRegisteredModels:
             registered_model_response_mock["name"],
         )
 
-        assert registered_model_version == new_registered_model_id
+        assert registered_model_version["id"] == new_registered_model_id
 
     @responses.activate
     def test_version_already_registered(
@@ -1660,7 +1660,7 @@ class TestRegisteredModels:
             registered_model_response_mock["name"],
         )
 
-        assert registered_model_version == registered_model_version_id
+        assert registered_model_version["id"] == registered_model_version_id
 
     @pytest.mark.parametrize("is_already_global", [True, False])
     @responses.activate

--- a/tests/unit/test_dr_client.py
+++ b/tests/unit/test_dr_client.py
@@ -1557,9 +1557,13 @@ class TestRegisteredModels:
 
     @pytest.fixture
     def patch_wait_for_async_resolution(self):
-        """Patch wait for async resolution method."""
+        """Patch wait for async resolution method to resolve to a fixed model package URL."""
 
-        with patch.object(DrClient, "_wait_for_async_resolution"):
+        with patch.object(
+            DrClient,
+            "_wait_for_async_resolution",
+            return_value="https://dr/api/v2/modelPackages/resolved_model_package/",
+        ):
             yield
 
     @pytest.mark.usefixtures("patch_wait_for_async_resolution")
@@ -1584,6 +1588,11 @@ class TestRegisteredModels:
             headers={"Location": "https://dr/api/v2/status/67baedd52a54aeda01837ccb"},
             json={"id": "new_registered_model_id"},
             status=201,
+        )
+        responses.get(
+            url="https://dr/api/v2/modelPackages/resolved_model_package/",
+            json={"id": "new_registered_model_id", "complianceDocsCount": None},
+            status=200,
         )
 
         registered_model_version = dr_client.create_or_update_registered_model(
@@ -1623,6 +1632,11 @@ class TestRegisteredModels:
             headers={"Location": "https://dr/api/v2/status/67baedd52a54aeda01837ccb"},
             json={"id": new_registered_model_id},
             status=201,
+        )
+        responses.get(
+            url="https://dr/api/v2/modelPackages/resolved_model_package/",
+            json={"id": new_registered_model_id, "complianceDocsCount": None},
+            status=200,
         )
         registered_model_version = dr_client.create_or_update_registered_model(
             custom_model_version_id,

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -1,0 +1,56 @@
+import pytest
+
+from model_info import ModelInfo
+from schema_validator import ModelSchema
+
+
+@pytest.fixture
+def model_info():
+    model_schema = {
+        ModelSchema.MODEL_ID_KEY: "abc123",
+        ModelSchema.TARGET_TYPE_KEY: ModelSchema.TARGET_TYPE_BINARY,
+        ModelSchema.SETTINGS_SECTION_KEY: {
+            ModelSchema.NAME_KEY: "Awesome Model",
+            ModelSchema.TARGET_NAME_KEY: "target_column",
+            ModelSchema.POSITIVE_CLASS_LABEL_KEY: "1",
+            ModelSchema.NEGATIVE_CLASS_LABEL_KEY: "0",
+        },
+        ModelSchema.VERSION_KEY: {
+            ModelSchema.MODEL_ENV_ID_KEY: "627790db5621558eedc4c7fa",
+            ModelSchema.RUNTIME_PARAMETER_VALUES_KEY: [
+                {
+                    "name": "param",
+                    "type": "numeric",
+                    "value": 42,
+                }
+            ],
+        },
+    }
+
+    metadata = ModelSchema.validate_and_transform_single(model_schema)
+    return ModelInfo("", "", metadata)
+
+
+@pytest.fixture
+def model_version():
+    return {
+        "baseEnvironmentId": "627790db5621558eedc4c7fa",
+        "runtimeParameters": [{"fieldName": "param", "type": "numeric", "currentValue": 42}],
+    }
+
+
+def test_should_create_new_version(model_info, model_version):
+    model_version["runtimeParameters"][0]["currentValue"] = 0
+
+    assert model_info.should_create_new_version(datarobot_latest_model_version=model_version)
+
+
+def test_should_not_create_new_version(model_info, model_version):
+    assert not model_info.should_create_new_version(datarobot_latest_model_version=model_version)
+
+
+def test_fail_when_runtime_parameter_does_not_exist(model_info, model_version):
+    model_version["runtimeParameters"] = []
+
+    with pytest.raises(ValueError, match="Model version on server does not have runtime param:"):
+        model_info.should_create_new_version(datarobot_latest_model_version=model_version)

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -1,3 +1,7 @@
+# pylint: disable=redefined-outer-name
+
+"""A module that contains unit-tests for the ModelInfo class."""
+
 import pytest
 
 from model_info import ModelInfo
@@ -6,6 +10,8 @@ from schema_validator import ModelSchema
 
 @pytest.fixture
 def model_info():
+    """A ModelInfo fixture with a single runtime parameter."""
+
     model_schema = {
         ModelSchema.MODEL_ID_KEY: "abc123",
         ModelSchema.TARGET_TYPE_KEY: ModelSchema.TARGET_TYPE_BINARY,
@@ -33,6 +39,8 @@ def model_info():
 
 @pytest.fixture
 def model_version():
+    """A DataRobot latest-version payload matching the model_info fixture's runtime parameter."""
+
     return {
         "baseEnvironmentId": "627790db5621558eedc4c7fa",
         "runtimeParameters": [{"fieldName": "param", "type": "numeric", "currentValue": 42}],
@@ -40,16 +48,22 @@ def model_version():
 
 
 def test_should_create_new_version(model_info, model_version):
+    """A changed runtime parameter value should require a new version."""
+
     model_version["runtimeParameters"][0]["currentValue"] = 0
 
     assert model_info.should_create_new_version(datarobot_latest_model_version=model_version)
 
 
 def test_should_not_create_new_version(model_info, model_version):
+    """An unchanged runtime parameter value should not require a new version."""
+
     assert not model_info.should_create_new_version(datarobot_latest_model_version=model_version)
 
 
 def test_fail_when_runtime_parameter_does_not_exist(model_info, model_version):
+    """A runtime parameter missing from the server's latest version should raise."""
+
     model_version["runtimeParameters"] = []
 
     with pytest.raises(ValueError, match="Model version on server does not have runtime param:"):

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -390,6 +390,8 @@ class TestModelSchemaValidator:
         ["string_value", True, 42, 42.2],
     )
     def test_runtime_parameters(self, regression_model_schema, value):
+        """A runtime parameter value of any of the supported scalar types should validate."""
+
         regression_model_schema[ModelSchema.VERSION_KEY][
             ModelSchema.RUNTIME_PARAMETER_VALUES_KEY
         ] = [{"name": "name", "type": "type", "value": value}]
@@ -404,6 +406,8 @@ class TestModelSchemaValidator:
         ],
     )
     def test_runtime_parameters_fail(self, regression_model_schema, parameters):
+        """An unsupported value type or a missing value should fail validation."""
+
         regression_model_schema[ModelSchema.VERSION_KEY][
             ModelSchema.RUNTIME_PARAMETER_VALUES_KEY
         ] = parameters

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -385,6 +385,32 @@ class TestModelSchemaValidator:
             in str(ex)
         )
 
+    @pytest.mark.parametrize(
+        "value",
+        ["string_value", True, 42, 42.2],
+    )
+    def test_runtime_parameters(self, regression_model_schema, value):
+        regression_model_schema[ModelSchema.VERSION_KEY][
+            ModelSchema.RUNTIME_PARAMETER_VALUES_KEY
+        ] = [{"name": "name", "type": "type", "value": value}]
+
+        self._validate_schema(True, regression_model_schema)
+
+    @pytest.mark.parametrize(
+        "parameters",
+        [
+            [{"name": "name", "type": "type", "value": ["list_value_not_allowed"]}],
+            [{"name": "name", "type": "type"}],  # Missing value
+        ],
+    )
+    def test_runtime_parameters_fail(self, regression_model_schema, parameters):
+        regression_model_schema[ModelSchema.VERSION_KEY][
+            ModelSchema.RUNTIME_PARAMETER_VALUES_KEY
+        ] = parameters
+
+        with pytest.raises(InvalidSchema):
+            self._validate_schema(True, regression_model_schema)
+
 
 class TestModelSchemaGetValue:
     """Contains cases to test the get value method from a model schema."""

--- a/tests/unit/test_yaml_exclusion.py
+++ b/tests/unit/test_yaml_exclusion.py
@@ -1,0 +1,70 @@
+#  Copyright (c) 2022. DataRobot, Inc. and its affiliates.
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+
+"""Unit tests for YAML file exclusion functionality."""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from model_controller import ModelController
+
+
+@pytest.mark.parametrize(
+    "exclude_pattern,expected_files",
+    [
+        (None, ["model1.yaml", "model2.yaml"]),  # No exclude pattern
+        ("test/", ["model1.yaml"]),  # Simple exclude
+        (".*test.*\.yaml$", ["model1.yaml"]),  # Complex regex
+        ("", ["model1.yaml", "model2.yaml"]),  # Empty pattern
+        ("model[12]\\.yaml", []),  # All models
+    ],
+)
+def test_yaml_file_exclusion(options, exclude_pattern, expected_files, workspace_path):
+    """Test that YAML files are properly excluded based on the exclude pattern."""
+    options.exclude = exclude_pattern
+    options.workspace_path = workspace_path  # Set workspace path in options
+    
+    # Create test files with valid YAML content
+    model1_content = {
+        "user_provided_model_id": "test/model1",
+        "target_type": "Regression",
+        "settings": {
+            "name": "Test Model 1",
+            "target_name": "target"
+        },
+        "version": {
+            "model_environment_id": "5e8c889607389fe0f466c72d"
+        }
+    }
+    
+    model2_content = {
+        "user_provided_model_id": "test/model2",
+        "target_type": "Regression",
+        "settings": {
+            "name": "Test Model 2",
+            "target_name": "target"
+        },
+        "version": {
+            "model_environment_id": "5e8c889607389fe0f466c72d"
+        }
+    }
+    
+    # Create directories and write YAML files
+    os.makedirs(workspace_path / "test", exist_ok=True)
+    with open(workspace_path / "model1.yaml", "w") as f:
+        yaml.dump(model1_content, f)
+    with open(workspace_path / "test/model2.yaml", "w") as f:
+        yaml.dump(model2_content, f)
+    
+    controller = ModelController(options, None)
+    
+    # Collect processed files
+    processed_files = [path for path, _ in controller._next_yaml_content_in_repo()]
+    processed_files = [Path(p).name for p in processed_files]
+    
+    assert set(processed_files) == set(expected_files) 

--- a/tests/unit/test_yaml_exclusion.py
+++ b/tests/unit/test_yaml_exclusion.py
@@ -28,43 +28,33 @@ def test_yaml_file_exclusion(options, exclude_pattern, expected_files, workspace
     """Test that YAML files are properly excluded based on the exclude pattern."""
     options.exclude = exclude_pattern
     options.workspace_path = workspace_path  # Set workspace path in options
-    
+
     # Create test files with valid YAML content
     model1_content = {
         "user_provided_model_id": "test/model1",
         "target_type": "Regression",
-        "settings": {
-            "name": "Test Model 1",
-            "target_name": "target"
-        },
-        "version": {
-            "model_environment_id": "5e8c889607389fe0f466c72d"
-        }
+        "settings": {"name": "Test Model 1", "target_name": "target"},
+        "version": {"model_environment_id": "5e8c889607389fe0f466c72d"},
     }
-    
+
     model2_content = {
         "user_provided_model_id": "test/model2",
         "target_type": "Regression",
-        "settings": {
-            "name": "Test Model 2",
-            "target_name": "target"
-        },
-        "version": {
-            "model_environment_id": "5e8c889607389fe0f466c72d"
-        }
+        "settings": {"name": "Test Model 2", "target_name": "target"},
+        "version": {"model_environment_id": "5e8c889607389fe0f466c72d"},
     }
-    
+
     # Create directories and write YAML files
     os.makedirs(workspace_path / "test", exist_ok=True)
     with open(workspace_path / "model1.yaml", "w") as f:
         yaml.dump(model1_content, f)
     with open(workspace_path / "test/model2.yaml", "w") as f:
         yaml.dump(model2_content, f)
-    
+
     controller = ModelController(options, None)
-    
+
     # Collect processed files
     processed_files = [path for path, _ in controller._next_yaml_content_in_repo()]
     processed_files = [Path(p).name for p in processed_files]
-    
-    assert set(processed_files) == set(expected_files) 
+
+    assert set(processed_files) == set(expected_files)

--- a/tests/unit/test_yaml_exclusion.py
+++ b/tests/unit/test_yaml_exclusion.py
@@ -3,6 +3,8 @@
 #  This is proprietary source code of DataRobot, Inc. and its affiliates.
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 
+# pylint: disable=protected-access
+
 """Unit tests for YAML file exclusion functionality."""
 
 import os
@@ -46,9 +48,9 @@ def test_yaml_file_exclusion(options, exclude_pattern, expected_files, workspace
 
     # Create directories and write YAML files
     os.makedirs(workspace_path / "test", exist_ok=True)
-    with open(workspace_path / "model1.yaml", "w") as f:
+    with open(workspace_path / "model1.yaml", "w", encoding="utf-8") as f:
         yaml.dump(model1_content, f)
-    with open(workspace_path / "test/model2.yaml", "w") as f:
+    with open(workspace_path / "test/model2.yaml", "w", encoding="utf-8") as f:
         yaml.dump(model2_content, f)
 
     controller = ModelController(options, None)

--- a/tests/unit/test_yaml_exclusion.py
+++ b/tests/unit/test_yaml_exclusion.py
@@ -19,7 +19,7 @@ from model_controller import ModelController
     [
         (None, ["model1.yaml", "model2.yaml"]),  # No exclude pattern
         ("test/", ["model1.yaml"]),  # Simple exclude
-        (".*test.*\.yaml$", ["model1.yaml"]),  # Complex regex
+        (r".*test.*\.yaml$", ["model1.yaml"]),  # Complex regex
         ("", ["model1.yaml", "model2.yaml"]),  # Empty pattern
         ("model[12]\\.yaml", []),  # All models
     ],


### PR DESCRIPTION
# RATIONALE
  <!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

`baekdahl/key-values` implements the `key_values` model-metadata feature that `global-envs-models` depends on (`Dockerfile:42`, `.github/workflows/global_models_deploy.yaml`), but has never been merged into `master`. It forked before April 2024 and diverged  - 34 commits of its own work, 12 behind master (including #361's Python 3.12 dataclass fix — see #377/#378 for that history).

Because `global-envs-models` clones `baekdahl/key-values` by branch name rather than a pinned commit, any push to that branch flows into DataRobot's production build with no review on our side. Upstreaming this feature into `master` lets `global-envs-models` depend on a real, reviewed commit instead of an untracked personal branch going forward.

This reuses the merge already done and verified in #378/#380 (`master` merged into `baekdahl/key-values`, `metrics.py` conflict resolved, confirmed byte-identical to master's fix, 10 pre-existing unit test failures unchanged) - same resulting tree, applied the other direction so it lands on `master` instead of continuing to live on an unreviewed branch.

## CHANGES

Brings `key_values` (and the rest of this branch's work — runtime-params, training-data handling, YAML exclusion support) onto current `master`. Purely additive relative to `master` — `metrics.py` does not appear in this diff at all, confirming master's Python 3.12 dataclass fix stays untouched


-----------------------------------------------------------------------------------------------
**CAUTION**: changing any of the checkbox states will immediately terminate a previous run that
is in progress.

- [ ] Skip functional tests
- [ ] Run all functional tests (>50 minutes)

**NOTE**: to run certain specific functional test(s), write a comment that includes the following
pattern `$FUNCTIONAL_TESTS=<tests-to-run>`. The test(s) specified after the assignment sign will be
executed. The execution can be viewed from the `Actions` tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to model sync, registry API calls, and deletion semantics can affect production CI/CD runs; credential and dataset upload paths add new failure modes.
> 
> **Overview**
> Adds **model registry** automation beyond basic registration: YAML can request **compliance doc** generation and **`key_values`** under `model_registry.version`, with create/update/delete sync against DataRobot model-package metadata. **`create_or_update_registered_model`** now returns the full registered-model-version object so that flow can run.
> 
> Extends **custom model versions** with **`resource_bundle_id`**, **`runtime_parameter_values`** (including credential name→id resolution), and optional **`training_dataset_file`** upload/dedup via catalog SHA naming. Version churn detection uses runtime params and camelCase **`trainingData`/`holdoutData`** fields.
> 
> Introduces optional **`--exclude`** (GitHub Action `exclude` input) to skip model YAML paths by regex; invalid YAML files are warned and skipped instead of failing the scan.
> 
> **Behavior change:** when models are missing locally and **`allow-model-deletion`** is false, the action **logs and continues** instead of raising **`IllegalModelDeletion`**. Settings-level “affected” diffing prefers the latest version’s git ancestor when a version exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce0b4cfd6f35f8fa087cb78f11f1195a08a15f9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->