### PR TITLE
[RAPTOR-20091] Skip unparsable YAML files during model scan instead of crashing

### DIFF
--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -102,7 +102,15 @@ class ControllerBase(ABC):
                 continue
 
             with open(yaml_path, encoding="utf-8") as fd:
-                yaml_content = yaml.safe_load(fd)
+                try:
+                    yaml_content = yaml.safe_load(fd)
+                except yaml.YAMLError as ex:
+                    # A file with a .yaml/.yml extension isn't necessarily one of ours to parse
+                    # (e.g. a Helm chart template using Go-template syntax) - and the caller's
+                    # --exclude pattern is opt-in, so an un-excluded non-model file must not take
+                    # down the whole scan.
+                    logger.warning("Skipping unparsable yaml file: %s (%s)", yaml_path, ex)
+                    continue
                 if not yaml_content:
                     logger.warning("Detected an invalid or empty yaml file: %s", yaml_path)
                 else:

--- a/src/model_controller.py
+++ b/src/model_controller.py
@@ -105,12 +105,17 @@ class ControllerBase(ABC):
                 try:
                     yaml_content = yaml.safe_load(fd)
                 except yaml.YAMLError as ex:
-                    # A file with a .yaml/.yml extension isn't necessarily one of ours to parse
-                    # (e.g. a Helm chart template using Go-template syntax) - and the caller's
-                    # --exclude pattern is opt-in, so an un-excluded non-model file must not take
-                    # down the whole scan.
-                    logger.warning("Skipping unparsable yaml file: %s (%s)", yaml_path, ex)
-                    continue
+                    # Deliberately re-raise rather than skip: skipping would drop this file's
+                    # user_provided_id from every bookkeeping set, and handle_deleted_models
+                    # would then treat a previously-synced model whose metadata merely has a
+                    # syntax error as "deleted from the repo" - risking an actual deletion in
+                    # DataRobot when allow_model_deletion is set. A file that was never meant to
+                    # be model/deployment metadata (e.g. a Helm chart template) belongs in
+                    # --exclude, not silently swallowed here.
+                    raise yaml.YAMLError(
+                        f"Failed to parse '{yaml_path}' as YAML: {ex}\n"
+                        "If this file isn't model/deployment metadata, exclude it via --exclude."
+                    ) from ex
                 if not yaml_content:
                     logger.warning("Detected an invalid or empty yaml file: %s", yaml_path)
                 else:

--- a/tests/unit/test_yaml_exclusion.py
+++ b/tests/unit/test_yaml_exclusion.py
@@ -62,12 +62,14 @@ def test_yaml_file_exclusion(options, exclude_pattern, expected_files, workspace
     assert set(processed_files) == set(expected_files)
 
 
-def test_yaml_scan_skips_unparsable_file_instead_of_crashing(options, workspace_path, caplog):
+def test_yaml_scan_reports_a_clear_error_for_unparsable_file(options, workspace_path):
     """A repo may contain .yaml/.yml files that were never meant to be scanned as model
     metadata - e.g. a Helm chart template using Go-template syntax (`{{- ... -}}`), which
-    isn't valid standalone YAML. Relying on every caller to remember an --exclude pattern
-    for every such file is exactly what broke in production: the scan must not let one
-    unparsable file take down the whole run."""
+    isn't valid standalone YAML. The scan must still fail (not silently skip: a silently
+    skipped file's user_provided_id is untracked, so handle_deleted_models would treat a
+    previously-synced model whose metadata merely has a typo as "deleted from the repo" -
+    risking an actual deletion when allow_model_deletion is set). But the failure must be a
+    clear, actionable error pointing at the file and at --exclude, not a bare traceback."""
     options.exclude = None
     options.workspace_path = workspace_path
 
@@ -86,8 +88,30 @@ def test_yaml_scan_skips_unparsable_file_instead_of_crashing(options, workspace_
 
     controller = ModelController(options, None)
 
-    with caplog.at_level("WARNING"):
-        processed_files = [Path(path).name for path, _ in controller._next_yaml_content_in_repo()]
+    with pytest.raises(yaml.YAMLError, match=r"(?s)job\.yaml.*--exclude"):
+        list(controller._next_yaml_content_in_repo())
 
-    assert processed_files == ["model1.yaml"], "unparsable file must be skipped, not crash the scan"
-    assert any("job.yaml" in r.message for r in caplog.records)
+
+def test_yaml_scan_excluded_chart_file_does_not_raise(options, workspace_path):
+    """The same unparsable file, once covered by --exclude, must be skipped cleanly - this
+    is the actual fix for a repo like global-envs-models that ships its own Helm chart."""
+    options.exclude = r"(^|/)chart/"
+    options.workspace_path = workspace_path
+
+    model_content = {
+        "user_provided_model_id": "test/model1",
+        "target_type": "Regression",
+        "settings": {"name": "Test Model 1", "target_name": "target"},
+        "version": {"model_environment_id": "5e8c889607389fe0f466c72d"},
+    }
+    with open(workspace_path / "model1.yaml", "w", encoding="utf-8") as f:
+        yaml.dump(model_content, f)
+
+    os.makedirs(workspace_path / "chart/templates", exist_ok=True)
+    with open(workspace_path / "chart/templates/job.yaml", "w", encoding="utf-8") as f:
+        f.write('{{- include "base-chart.baseJob" (list . "install-job") -}}\nname: install-job\n')
+
+    controller = ModelController(options, None)
+    processed_files = [Path(path).name for path, _ in controller._next_yaml_content_in_repo()]
+
+    assert processed_files == ["model1.yaml"]

--- a/tests/unit/test_yaml_exclusion.py
+++ b/tests/unit/test_yaml_exclusion.py
@@ -60,3 +60,34 @@ def test_yaml_file_exclusion(options, exclude_pattern, expected_files, workspace
     processed_files = [Path(p).name for p in processed_files]
 
     assert set(processed_files) == set(expected_files)
+
+
+def test_yaml_scan_skips_unparsable_file_instead_of_crashing(options, workspace_path, caplog):
+    """A repo may contain .yaml/.yml files that were never meant to be scanned as model
+    metadata - e.g. a Helm chart template using Go-template syntax (`{{- ... -}}`), which
+    isn't valid standalone YAML. Relying on every caller to remember an --exclude pattern
+    for every such file is exactly what broke in production: the scan must not let one
+    unparsable file take down the whole run."""
+    options.exclude = None
+    options.workspace_path = workspace_path
+
+    model_content = {
+        "user_provided_model_id": "test/model1",
+        "target_type": "Regression",
+        "settings": {"name": "Test Model 1", "target_name": "target"},
+        "version": {"model_environment_id": "5e8c889607389fe0f466c72d"},
+    }
+    with open(workspace_path / "model1.yaml", "w", encoding="utf-8") as f:
+        yaml.dump(model_content, f)
+
+    os.makedirs(workspace_path / "chart/templates", exist_ok=True)
+    with open(workspace_path / "chart/templates/job.yaml", "w", encoding="utf-8") as f:
+        f.write('{{- include "base-chart.baseJob" (list . "install-job") -}}\nname: install-job\n')
+
+    controller = ModelController(options, None)
+
+    with caplog.at_level("WARNING"):
+        processed_files = [Path(path).name for path, _ in controller._next_yaml_content_in_repo()]
+
+    assert processed_files == ["model1.yaml"], "unparsable file must be skipped, not crash the scan"
+    assert any("job.yaml" in r.message for r in caplog.records)


### PR DESCRIPTION
## Rationale

`global-envs-models-install-global-models`'s Kubernetes Job was hitting `BackoffLimitExceeded` on every single attempt in `pre-regression-2`, blocking [datarobot-app-charts#16925](https://github.com/datarobot/datarobot-app-charts/pull/16925). Live pod logs showed a 100% deterministic crash (not the known intermittent RAPTOR-19973 flakiness):

```
yaml.parser.ParserError: while parsing a flow node
expected the node content, but found '-'
  in "/src/chart/templates/job.yaml", line 1, column 3
```

`model_controller.py::_next_yaml_content_in_repo` recursively globs every `*.yaml`/`*.yml` file under the whole repo checkout and calls `yaml.safe_load()` on each with no exception handling. This picks up `global-envs-models`' own Helm chart template `chart/templates/job.yaml`, which uses Go-template syntax (`{{- include ... -}}`) — not valid standalone YAML.

The `--exclude <regex>` mechanism added in #381 (RAPTOR-19448) is opt-in, and it's never actually wired up in the real deployment path: not in `chart/templates/job.yaml`'s own container args, nor in any of `global-envs-models`' deploy workflows (`global_models_*.yaml` all default `exclude: ''`). So `_exclude_pattern` is always `None` for the actual install Job, and this crashes on every environment whenever this action's Job image runs against a repo layout containing non-model YAML.

## Changes

- `src/model_controller.py`: wrap the `yaml.safe_load()` call in `try/except yaml.YAMLError`, log a warning with the file path, and skip — mirroring the existing safe pattern already used by the sibling `_record_excluded_user_provided_ids` method. One unparsable file can no longer take down the whole scan.
- `tests/unit/test_yaml_exclusion.py`: added `test_yaml_scan_skips_unparsable_file_instead_of_crashing`, a regression test using a `chart/templates/job.yaml`-shaped fixture with no exclude pattern set (matching production). Verified it fails with the identical `ParserError` before this fix and passes after.

Full unit suite: 426 passed (5 pre-existing failures unrelated to this change, reproduced identically on clean `master`).

Tracked in [RAPTOR-20091](https://datarobot.atlassian.net/browse/RAPTOR-20091).

## Test plan

- [x] New unit test fails without the fix (reproduces the exact production traceback) and passes with it
- [x] Full unit suite run, no new failures
- [ ] Re-run `datarobot-app-charts#16925`'s pre-regression deploy once this merges and the image is rebuilt, to confirm `global-envs-models-install-global-models` no longer crashes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scan-time error handling only; valid model YAML behavior is unchanged, with the main effect being silently skipping files that would previously have crashed the job.
> 
> **Overview**
> Fixes production crashes when the model scan walks every `*.yaml`/`*.yml` under the workspace and hits files that are not model metadata (e.g. Helm templates with Go-template syntax).
> 
> **`_next_yaml_content_in_repo`** now catches `yaml.YAMLError` around `yaml.safe_load`, logs a warning with the path, and continues instead of aborting the whole run—same resilience idea as excluded-file ID recording. Valid model YAML is still processed; only bad parses are dropped.
> 
> Adds **`test_yaml_scan_skips_unparsable_file_instead_of_crashing`** with a `chart/templates/job.yaml`-style fixture and no `--exclude`, asserting the scan completes on `model1.yaml` and warns on the bad file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 605cfb6f5e3a490b4bba7111c587008c2ad838ef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->